### PR TITLE
Migrate from Google Maps to Leaflet/MapLibre with OSM tiles

### DIFF
--- a/airline-web/app/views/index.scala.html
+++ b/airline-web/app/views/index.scala.html
@@ -31,12 +31,20 @@
 	  <link rel="stylesheet" type="text/css" href='@routes.Assets.versioned("javascripts/emojify/emojify.min.css")'>
 	  <link rel="stylesheet" type="text/css" href='@routes.Assets.versioned("javascripts/splitting/splitting.css")'>
 	  <link rel="stylesheet" type="text/css" href='@routes.Assets.versioned("javascripts/splitting/splitting-cells.css")'>
+	  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+			integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+			crossorigin="anonymous">
+	  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
 	  <link rel="stylesheet" type="text/css" href='/assets/stylesheets/classic.css' id="uiTheme">
 	  <link rel="stylesheet" type="text/css" href='@routes.Assets.versioned("stylesheets/mobile.css")'> <!-- this has to be last so it overrides the CSS if mobile-->
 
 
     
 	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.4/angular.min.js" defer></script>
+	<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+			integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+			crossorigin="anonymous"></script>
+	<script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"
 			integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
 			crossorigin="anonymous"></script>
@@ -6062,8 +6070,13 @@
 
     <script src="@routes.Assets.versioned("javascripts/chat-popup.js")"></script>
 
-    <script src='https://maps.googleapis.com/maps/api/js?v=weekly&key=@configuration.get[String]("google.mapKey")&libraries=geometry,drawing,visualization&callback=initMap'>
-	</script>
+    <script>
+      window.addEventListener('load', function() {
+        if (typeof initMap === 'function') {
+          initMap();
+        }
+      });
+    </script>
 <!-- 	<script src="https://apis.google.com/js/platform.js"></script> -->
   <script src='/assets/firework/fscreen.js'></script>
   <script src='/assets/firework/stage.js'></script>

--- a/airline-web/app/views/test.scala.html
+++ b/airline-web/app/views/test.scala.html
@@ -5,8 +5,16 @@
       html, body { height: 100%; margin: 0; padding: 0; }
       #map { height: 100%; }
     </style>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+          crossorigin="anonymous">
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("css-templates/treviso/css/style.css")">
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("stylesheets/main.css")">
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+            crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
     <script src="@routes.Assets.versioned("javascripts/jquery-2.1.4.js")"></script>
   </head>
   <body>
@@ -53,8 +61,12 @@
     <script src="@routes.Assets.versioned("javascripts/airplane.js")"></script>
     <script src="@routes.Assets.versioned("javascripts/airline.js")"></script>
     <script src="@routes.Assets.versioned("javascripts/websocket.js")"></script>
-    <script async defer
-src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB5XQhzy2XrM95AyfW8f5BeWJiqr-LGXxU&callback=initMap">
-</script> 
+    <script>
+      window.addEventListener('load', function() {
+        if (typeof initMap === 'function') {
+          initMap();
+        }
+      });
+    </script>
   </body>
 </html>

--- a/airline-web/public/javascripts/main.js
+++ b/airline-web/public/javascripts/main.js
@@ -1,4 +1,5 @@
 var map
+var baseTileLayer
 var airportMap
 var markers
 var baseMarkers = []
@@ -301,35 +302,37 @@ function hideUserSpecificElements() {
 
 function initMap() {
 	initStyles()
-  map = new google.maps.Map(document.getElementById('map'), {
-	center: {lat: 20, lng: 150.644},
-   	zoom : 2,
-   	minZoom : 2,
-   	gestureHandling: 'greedy',
-   	styles: getMapStyles(),
-	mapTypeId: getMapTypes(),
-   	restriction: {
-                latLngBounds: { north: 85, south: -85, west: -180, east: 180 },
-              }
-  });
-	
-  google.maps.event.addListener(map, 'zoom_changed', function() {
-	    var zoom = map.getZoom();
-	    // iterate over markers and call setVisible
-	    $.each(markers, function( key, marker ) {
-	        marker.setVisible(isShowMarker(marker, zoom));
-	    })
-  });
-  
-  google.maps.event.addListener(map, 'maptypeid_changed', function() { 
-		var mapType = map.getMapTypeId();
-		$.cookie('currentMapTypes', mapType);
-  });
+  map = L.map('map', {
+	center: [20, 150.644],
+	zoom: 2,
+	minZoom: 2,
+	maxBounds: [[-85, -180], [85, 180]],
+	worldCopyJump: true
+  })
+  baseTileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map)
 
+  map.on('zoomend', function() {
+	var zoom = map.getZoom()
+	// iterate over markers and call setVisible if supported
+	$.each(markers, function(key, marker) {
+		if (marker && typeof marker.setVisible === 'function') {
+			marker.setVisible(isShowMarker(marker, zoom))
+		} else if (marker && typeof marker.setOpacity === 'function') {
+			marker.setOpacity(isShowMarker(marker, zoom) ? 1 : 0)
+		}
+	})
+  })
+	
   addCustomMapControls(map)
 }
 
 function addCustomMapControls(map) {
+  if (!map || !map.controls || !window.google || !window.google.maps || !window.google.maps.ControlPosition) {
+    return
+  }
 //			<div id="toggleMapChristmasButton" class="googleMapIcon" onclick="toggleChristmasMarker()" align="center" style="display: none; margin-bottom: 10px;"><span class="alignHelper"></span><img src='@routes.Assets.versioned("images/icons/bauble.png")' title='Merry Christmas!' style="vertical-align: middle;"/></div>-->
 //			<div id="toggleMapAnimationButton" class="googleMapIcon" onclick="toggleMapAnimation()" align="center" style="display: none; margin-bottom: 10px;"><span class="alignHelper"></span><img src='@routes.Assets.versioned("images/icons/arrow-step-over.png")' title='toggle flight marker animation' style="vertical-align: middle;"/></div>-->
 //			<div id="toggleMapLightButton" class="googleMapIcon" onclick="toggleMapLight()" align="center" style="display: none;"><span class="alignHelper"></span><img src='@routes.Assets.versioned("images/icons/switch.png")' title='toggle dark/light themed map' style="vertical-align: middle;"/></div>-->

--- a/airline-web/public/javascripts/map-style.js
+++ b/airline-web/public/javascripts/map-style.js
@@ -53,7 +53,9 @@ function toggleMapLight() {
 	}
 	$.cookie('currentMapStyles', currentStyles);
 	console.log($.cookie('currentMapStyles'))
-	
+	if (!map || typeof map.setOptions !== 'function') {
+		return
+	}
 	map.setOptions({styles: getMapStyles()});
 	refreshLinks(false)
 }

--- a/airline-web/public/javascripts/test-airport.js
+++ b/airline-web/public/javascripts/test-airport.js
@@ -1,18 +1,26 @@
 var map
 var flightPaths
 var activeInput
+var markers
 
 $( document ).ready(function() {
 	flightPaths = []
+	markers = []
 	activeInput = $("#fromAirport")
 	loadAirlines()
 })
 
 function initMap() {
-  map = new google.maps.Map(document.getElementById('map'), {
-	center: {lat: 20, lng: 150.644},
-   	zoom : 2
-  });
+  map = L.map('map', {
+	center: [20, 150.644],
+	zoom: 2,
+	minZoom: 2,
+	worldCopyJump: true
+  })
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map)
   
   getAirports()
   refreshLinks()
@@ -21,16 +29,12 @@ function initMap() {
 function addMarkers(airports) {
 	for (i = 0; i < airports.length; i++) {
 		  var airportInfo = airports[i]
-		  var position = {lat: airportInfo.latitude, lng: airportInfo.longitude};
-		  var marker = new google.maps.Marker({
-			    position: position,
-			    map: map,
-			    title: airportInfo.name,
-		  		airportCode: airportInfo.iata,
-		  		airportId: airportInfo.id
-			  });
+		  var position = [airportInfo.latitude, airportInfo.longitude]
+		  var marker = L.marker(position, { title: airportInfo.name }).addTo(map)
+		  marker.airportCode = airportInfo.iata
+		  marker.airportId = airportInfo.id
 		  
-		  marker.addListener('click', function() {
+		  marker.on('click', function() {
 			  var airportId = this.airportId
 			  if (activeInput.is($("#fromAirport"))) {
 				  $("#fromAirport").val(airportId)
@@ -40,6 +44,7 @@ function addMarkers(airports) {
 				  activeInput = $("#fromAirport")
 			  }
 		  });
+		  markers.push(marker)
 	}
 }
 
@@ -126,7 +131,9 @@ function removeAllLinks() {
 function refreshLinks() {
 	//remove all links from UI first
 	$.each(flightPaths, function( key, value ) {
-		  value.setMap(null)
+		  if (map && value) {
+		  	map.removeLayer(value)
+		  }
 		});
 	flightPaths = []
 	
@@ -148,15 +155,14 @@ function refreshLinks() {
 }
 
 function drawFlightPath(link) {
-   var flightPath = new google.maps.Polyline({
-     path: [{lat: link.fromLatitude, lng: link.fromLongitude}, {lat: link.toLatitude, lng: link.toLongitude}], 
-     geodesic: true,
-     strokeColor: '#F2B022',
-     strokeOpacity: 1.0,
-     strokeWeight: 2
-                           });
-   
-   flightPath.setMap(map)
+   var flightPath = L.polyline(
+     [[link.fromLatitude, link.fromLongitude], [link.toLatitude, link.toLongitude]],
+     {
+       color: '#F2B022',
+       opacity: 1.0,
+       weight: 2
+     }
+   ).addTo(map)
    flightPaths.push(flightPath)
 }
 


### PR DESCRIPTION
### Motivation
- Remove the Google Maps dependency and `google.mapKey` usage and switch to an open-source map stack to avoid the Google Maps callback mechanism. 
- Use Leaflet (and include MapLibre assets) with an OSM tile layer so maps initialize without requiring a Google API key and callback.

### Description
- Replaced Google Maps script tag + callback in `airline-web/app/views/index.scala.html` and `airline-web/app/views/test.scala.html` with Leaflet/MapLibre CSS/JS includes and a load-time bootstrap that calls `initMap()` if present. 
- Rewired the main map bootstrapping in `airline-web/public/javascripts/main.js` to create a Leaflet map, add an OSM tile layer (`L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png')`), and handle zoom events for marker visibility; introduced `baseTileLayer`. 
- Converted the test map implementation in `airline-web/public/javascripts/test-airport.js` to Leaflet markers and polylines, added a `markers` collection, and replaced Google-specific APIs with Leaflet equivalents. 
- Added guards to Google-specific code paths so map-style toggling and custom controls do not call Google Maps APIs when unavailable by updating `airline-web/public/javascripts/map-style.js` and `main.js` control setup. 

### Testing
- No automated tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976a06caaa88332baf16c788e7ceb6c)