### PR TITLE
Migrate map rendering from Google Maps to Leaflet

### DIFF
--- a/airline-web/app/views/index.scala.html
+++ b/airline-web/app/views/index.scala.html
@@ -6009,6 +6009,8 @@
   <link rel="preconnect" href="https://p.typekit.net" crossorigin />
   <link rel="preload" href="https://p.typekit.net" crossorigin>
   <link rel="stylesheet" href="https://use.typekit.net/plw0ulw.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src='@routes.Assets.versioned("javascripts/main.js")'></script>
   <script defer src='@routes.Assets.versioned("javascripts/airport.js")'></script>
   <script src='@routes.Assets.versioned("javascripts/airport-asset.js")'></script>
@@ -6062,8 +6064,7 @@
 
     <script src="@routes.Assets.versioned("javascripts/chat-popup.js")"></script>
 
-    <script src='https://maps.googleapis.com/maps/api/js?v=weekly&key=@configuration.get[String]("google.mapKey")&libraries=geometry,drawing,visualization&callback=initMap'>
-	</script>
+    
 <!-- 	<script src="https://apis.google.com/js/platform.js"></script> -->
   <script src='/assets/firework/fscreen.js'></script>
   <script src='/assets/firework/stage.js'></script>

--- a/airline-web/app/views/test.scala.html
+++ b/airline-web/app/views/test.scala.html
@@ -7,7 +7,9 @@
     </style>
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("css-templates/treviso/css/style.css")">
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("stylesheets/main.css")">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
     <script src="@routes.Assets.versioned("javascripts/jquery-2.1.4.js")"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   </head>
   <body>
   	<div id="topBar" data-scroll="false" class="menubar">
@@ -53,8 +55,5 @@
     <script src="@routes.Assets.versioned("javascripts/airplane.js")"></script>
     <script src="@routes.Assets.versioned("javascripts/airline.js")"></script>
     <script src="@routes.Assets.versioned("javascripts/websocket.js")"></script>
-    <script async defer
-src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB5XQhzy2XrM95AyfW8f5BeWJiqr-LGXxU&callback=initMap">
-</script> 
   </body>
 </html>

--- a/airline-web/public/javascripts/airline.js
+++ b/airline-web/public/javascripts/airline.js
@@ -218,13 +218,13 @@ function clearMarkerEntry(markerEntry) {
 
 	//remove all markers
 	$.each(markerEntry.markers, function(key, marker) {
-		marker.setMap(null)
+		setLeafletLayerVisibility(marker, false)
 	})
 }
 
 function clearPathEntry(pathEntry) {
-	pathEntry.path.setMap(null)
-	pathEntry.shadow.setMap(null)
+	setLeafletLayerVisibility(pathEntry.path, false)
+	setLeafletLayerVisibility(pathEntry.shadow, false)
 }
 
 function clearAllPaths() {
@@ -240,13 +240,13 @@ function clearAllPaths() {
 	flightMarkers = {}
 
 	$.each(polylines, function(index, polyline) {
-		if (polyline.getMap() != null) {
-			polyline.setMap(null)
+		if (map && map.hasLayer(polyline)) {
+			map.removeLayer(polyline)
 		}
 	})
 
 	polylines = polylines.filter(function(polyline) {
-	    return polyline.getMap() != null
+	    return map && map.hasLayer(polyline)
 	})
 }
 
@@ -307,36 +307,33 @@ function drawFlightPath(link, linkColor) {
    if (!linkColor) {
 	   linkColor = getLinkColor(link.profit, link.revenue)
    }
-   var flightPath = new google.maps.Polyline({
-     path: [{lat: link.fromLatitude, lng: link.fromLongitude}, {lat: link.toLatitude, lng: link.toLongitude}],
-     geodesic: true,
-     strokeColor: linkColor,
-     strokeOpacity: pathOpacityByStyle[currentStyles].normal,
-     strokeWeight: 2,
-     frequency : link.frequency,
-     modelId : link.modelId,
-     link : link,
-     zIndex: 90
-   });
+   var flightPath = L.polyline([[link.fromLatitude, link.fromLongitude], [link.toLatitude, link.toLongitude]], {
+       color: linkColor,
+       opacity: pathOpacityByStyle[currentStyles].normal,
+       weight: 2
+   })
+   flightPath.frequency = link.frequency
+   flightPath.modelId = link.modelId
+   flightPath.link = link
+   flightPath.originalStrokeWeight = 2
+   flightPath.originalZIndex = 90
 
-   var icon = "assets/images/icons/airplane.png"
-
-   flightPath.setMap(map)
+   flightPath.addTo(map)
+   flightPath.__mapRef = map
    polylines.push(flightPath)
 
-   var shadowPath = new google.maps.Polyline({
-	     path: [{lat: link.fromLatitude, lng: link.fromLongitude}, {lat: link.toLatitude, lng: link.toLongitude}],
-	     geodesic: true,
-	     map: map,
-	     strokeColor: getLinkColor(link.profit, link.revenue),
-	     strokeOpacity: 0.001,
-	     strokeWeight: 15,
-	     zIndex: 100
-	   });
+   var shadowPath = L.polyline([[link.fromLatitude, link.fromLongitude], [link.toLatitude, link.toLongitude]], {
+       color: getLinkColor(link.profit, link.revenue),
+       opacity: 0.001,
+       weight: 15,
+       interactive: true
+   })
+   shadowPath.addTo(map)
+   shadowPath.__mapRef = map
 
    var resultPath = { path : flightPath, shadow : shadowPath }
    if (link.id) {
-	  shadowPath.addListener('click', function() {
+	  shadowPath.on('click', function() {
 	   		selectLinkFromMap(link.id, false)
 	  });
       drawFlightMarker(flightPath, link);
@@ -355,7 +352,7 @@ function refreshFlightPath(link, forceRedraw) {
 
 			drawFlightMarker(path, link)
 		}
-		path.setOptions({ strokeColor : getLinkColor(link.profit, link.revenue), strokeOpacity : pathOpacityByStyle[currentStyles].normal })
+		path.setStyle({ color: getLinkColor(link.profit, link.revenue), opacity: pathOpacityByStyle[currentStyles].normal })
 
 		//flightPaths[link.id].setOptions({ strokeColor : getLinkColor(link)})
 	}
@@ -413,19 +410,19 @@ function highlightPath(path, refocus) {
 	refocus = refocus || false
 	//focus to the from airport
 	if (refocus) {
-		map.setCenter(path.getPath().getAt(0))
+		var firstPoint = path.getLatLngs()[0]
+		map.setView(firstPoint, map.getZoom())
 	}
 
 
 	if (!path.highlighted) { //only highlight again if it's not already done so
-	    var originalColorString = path.strokeColor
+	    var originalColorString = path.options.color
 		//keep track of original values so we can revert...shouldn't there be a better way to just get all options all at once?
 		path.originalColor = originalColorString
-		path.originalStrokeWeight = path.strokeWeight
-		path.originalZIndex = path.zIndex
-		path.originalStrokeOpacity = path.strokeOpacity
+		path.originalStrokeWeight = path.options.weight
+		path.originalStrokeOpacity = path.options.opacity
 
-		path.setOptions({ strokeOpacity : pathOpacityByStyle[currentStyles].highlight })
+		path.setStyle({ opacity: pathOpacityByStyle[currentStyles].highlight })
 		var totalFrames = 20
 
 		var rgbHexValue = parseInt(originalColorString.substring(1), 16);
@@ -454,7 +451,8 @@ function highlightPath(path, refocus) {
 			}
 
 			var colorHexString = "#" + redHex + greenHex + blueHex
-			path.setOptions({ strokeColor : colorHexString , strokeWeight : 4, zIndex : 91})
+			path.setStyle({ color: colorHexString, weight: 4 })
+			path.bringToFront()
 
 			currentFrame = (currentFrame + 1) % (totalFrames * 2)
 
@@ -468,7 +466,7 @@ function highlightPath(path, refocus) {
 function unhighlightPath(path) {
 	window.clearInterval(path.animation)
 	path["animation"] = undefined
-	path.setOptions({ strokeColor : path.originalColor , strokeWeight : path.originalStrokeWeight, zIndex : path.originalZIndex, strokeOpacity : path.originalStrokeOpacity})
+	path.setStyle({ color: path.originalColor, weight: path.originalStrokeWeight, opacity: path.originalStrokeOpacity })
 	
 	delete path.highlighted
 }
@@ -495,13 +493,9 @@ function drawFlightMarker(line, link) {
 	}
 
 	if (currentAnimationStatus && link.assignedAirplanes && link.assignedAirplanes.length > 0) {
-		var from = line.getPath().getAt(0)
-		var to = line.getPath().getAt(1)
-		var image = {
-	        url: "assets/images/markers/dot.png",
-	        origin: new google.maps.Point(0, 0),
-	        anchor: new google.maps.Point(6, 6),
-	    };
+		var from = line.getLatLngs()[0]
+		var to = line.getLatLngs()[1]
+		var image = createLeafletIcon("assets/images/markers/dot.png", { size: [12, 12], anchor: [6, 6] })
 
 
 
@@ -523,17 +517,18 @@ function drawFlightMarker(line, link) {
 
 		var markersOfThisLink = []
 		for (i = 0; i < markersRequired; i ++) {
-			var marker = new google.maps.Marker({
-			    position: from,
-			    icon : image,
-			    totalDuration : link.duration * 2, //round trip
-			    elapsedDuration : 0,
-			    nextDepartureFrame : Math.floor((i + 0.1) * totalIntervalsPerWeek / frequency) % totalIntervalsPerWeek, //i + 0.1 so they wont all depart at the same time
-				departureInterval : Math.floor(totalIntervalsPerWeek / markersRequired),
-				status : "forward",
-			    isActive: false,
-			    clickable: false,
-			});
+			var marker = L.marker(from, {
+			    icon: image,
+                opacity: 1,
+                keyboard: false
+			})
+            marker.__mapRef = map
+            marker.totalDuration = link.duration * 2 //round trip
+            marker.elapsedDuration = 0
+            marker.nextDepartureFrame = Math.floor((i + 0.1) * totalIntervalsPerWeek / frequency) % totalIntervalsPerWeek //i + 0.1 so they wont all depart at the same time
+            marker.departureInterval = Math.floor(totalIntervalsPerWeek / markersRequired)
+            marker.status = "forward"
+            marker.isActive = false
 
 			//flightMarkers.push(marker)
 			markersOfThisLink.push(marker)
@@ -547,17 +542,13 @@ function drawFlightMarker(line, link) {
 			$.each(markersOfThisLink, function(key, marker) {
 				if (count == marker.nextDepartureFrame) {
 					if (christmasMarker) {
-						marker.icon = {
-						        url: randomFlightMarker(),
-						        origin: new google.maps.Point(0, 0),
-						        anchor: new google.maps.Point(6, 6),
-						    };
+                        marker.setIcon(createLeafletIcon(randomFlightMarker(), { size: [16, 16], anchor: [8, 8] }))
 					}
 					marker.status = "forward"
 					marker.isActive = true
 					marker.elapsedDuration = 0
-					marker.setPosition(from)
-					marker.setMap(map)
+					marker.setLatLng(from)
+					setLeafletLayerVisibility(marker, true)
 				} else if (marker.isActive) {
 					marker.elapsedDuration += minsPerInterval
 
@@ -572,8 +563,8 @@ function drawFlightMarker(line, link) {
 					         if (marker.elapsedDuration / marker.totalDuration >= 0.45) { //finished forward, now go into turnaround
                                 marker.status = "turnaround"
 					         } else {
-					            var newPosition = google.maps.geometry.spherical.interpolate(from, to, marker.elapsedDuration / marker.totalDuration / 0.45)
-                                marker.setPosition(newPosition)
+					            var newPosition = interpolateGreatCircle(from, to, marker.elapsedDuration / marker.totalDuration / 0.45)
+                                marker.setLatLng(newPosition)
                              }
                         }
                         if (marker.status === "turnaround") {
@@ -582,8 +573,8 @@ function drawFlightMarker(line, link) {
                              }
                         }
                         if (marker.status === "backward") {
-                            var newPosition = google.maps.geometry.spherical.interpolate(to, from, (marker.elapsedDuration / marker.totalDuration - 0.55) / 0.45)
-                            marker.setPosition(newPosition)
+                            var newPosition = interpolateGreatCircle(to, from, (marker.elapsedDuration / marker.totalDuration - 0.55) / 0.45)
+                            marker.setLatLng(newPosition)
                         }
 
 					}
@@ -873,7 +864,7 @@ function fadeOutMarker(marker, animationInterval) {
     var opacity = 1.0
     var animation = window.setInterval(function () {
         if (opacity <= 0) {
-            marker.setMap(null)
+            setLeafletLayerVisibility(marker, false)
             marker.setOpacity(1)
             window.clearInterval(animation)
         } else {

--- a/airline-web/public/javascripts/airport.js
+++ b/airline-web/public/javascripts/airport.js
@@ -366,29 +366,19 @@ function updateAirportChampionDetails(airport) {
 }
 
 function initAirportMap() { //only called once, see https://stackoverflow.com/questions/10485582/what-is-the-proper-way-to-destroy-a-map-instance
-    airportMap = new google.maps.Map(document.getElementById('airportMap'), {
-		//center: {lat: airport.latitude, lng: airport.longitude},
-	   	//zoom : 6,
-	   	minZoom : 2,
-	   	maxZoom : 9,
-//	   	scrollwheel: false,
-//	    navigationControl: false,
-//	    mapTypeControl: false,
-//	    scaleControl: false,
-//	    draggable: false,
-	   	gestureHandling: 'greedy',
-	   	fullscreenControl: false,
-	   	streetViewControl: false,
-        zoomControl: true,
-	   	styles: getMapStyles()
-	});
+    airportMap = L.map(document.getElementById('airportMap'), {
+        minZoom: 2,
+        maxZoom: 9,
+        zoomControl: true
+    })
+    applyMapStyle(airportMap)
 
     if (christmasFlag) {
         //<div id="santaClausButton" class="googleMapIcon glow" onclick="showSantaClausAttemptStatus()" align="center" style="display: none; margin-bottom: 10px;"><span class="alignHelper"></span><img src='@routes.Assets.versioned("images/markers/christmas/santa-hat.png")' title='Santa, where are you?' style="vertical-align: middle;"/></div>-->
         var santaClausButton = $('<div id="santaClausButton" class="googleMapIcon glow" onclick="showSantaClausAttemptStatus()" align="center" style="margin-bottom: 10px;"><span class="alignHelper"></span><img src="assets/images/markers/christmas/santa-hat.png" title=\'Santa, where are you!\' style="vertical-align: middle;"/></div>')
 
         santaClausButton.index = 1
-        airportMap.controls[google.maps.ControlPosition.RIGHT_BOTTOM].push(santaClausButton[0]);
+        addLeafletControlElement(airportMap, "bottomright", santaClausButton[0])
     }
 }
 
@@ -644,49 +634,31 @@ function getAirports() {
 }
 
 function addMarkers(airports) {
-    var infoWindow = new google.maps.InfoWindow({
-		maxWidth : 250
-	})
 	var originalOpacity = 0.7
 	currentZoom = map.getZoom()
-
-	google.maps.event.addListener(infoWindow, 'closeclick',function(){
-       if (infoWindow.marker) {
-        infoWindow.marker.setOpacity(originalOpacity)
-       }
-    });
 
 	var resultMarkers = {}
 	for (i = 0; i < airports.length; i++) {
 		  var airportInfo = airports[i]
-		  var position = {lat: airportInfo.latitude, lng: airportInfo.longitude};
 		  var icon = getAirportIcon(airportInfo)
 //          if (airportInfo.championAirlineName) {
 //            console.log(airportInfo.name + "-> " + airportInfo.championAirlineName)
 //          }
 
 		  
-		  var marker = new google.maps.Marker({
-			    position: position,
-			    map: map,
-			    title: airportInfo.name,
-			    airportName: airportInfo.name,
-//		  		airportCode: airportInfo.iata,
-//		  		airportCity: airportInfo.city,
-//		  		airportId: airportInfo.id,
-//		  		airportSize: airportInfo.size,
-//		  		airportPopulation: airportInfo.population,
-//		  		airportIncomeLevel: airportInfo.incomeLevel,
-//		  		airportCountryCode: airportInfo.countryCode,
-//		  		airportZone : airportInfo.zone,
-//		  		airportAvailableSlots: airportInfo.availableSlots,
+		  var marker = L.marker([airportInfo.latitude, airportInfo.longitude], {
+                title: airportInfo.name,
                 opacity: originalOpacity,
-		  		airport : airportInfo,
-		  		icon: icon,
-		  		originalIcon: icon, //so we can flip back and forth
-			  });
+                icon: icon
+              })
+          marker.__mapRef = map
+          marker.airportName = airportInfo.name
+          marker.title = airportInfo.name
+          marker.airport = airportInfo
+          marker.icon = icon
+          marker.originalIcon = icon //so we can flip back and forth
 		  if (airportInfo.championAirlineId) {
-            marker.championIcon = '/airlines/' + airportInfo.championAirlineId + '/logo'
+            marker.championIcon = createLeafletIcon('/airlines/' + airportInfo.championAirlineId + '/logo', { size: [32, 32], anchor: [16, 16] })
             marker.championAirlineName = airportInfo.championAirlineName
             marker.contested = airportInfo.contested
           }
@@ -699,12 +671,11 @@ function addMarkers(airports) {
 		  }
 		  zIndex += sizeAdjust
 		  
-		  marker.setZIndex(zIndex); //major airport should have higher index
+		  marker.setZIndexOffset(zIndex); //major airport should have higher index
 
-		  marker.addListener('click', function() {
-			  infoWindow.close();
-			  if (infoWindow.marker && infoWindow.marker != this) {
-			    infoWindow.marker.setOpacity(originalOpacity)
+		  marker.on('click', function() {
+			  if (activeAirportPopupInfoWindow && activeAirportPopupInfoWindow.marker && activeAirportPopupInfoWindow.marker != this) {
+                  activeAirportPopupInfoWindow.marker.setOpacity(originalOpacity)
               }
 			  
 			  activeAirport = this.airport
@@ -730,11 +701,9 @@ function addMarkers(airports) {
 			  var popup = $("#airportPopup").clone()
 			  populateNavigation(popup)
 			  popup.show()
-			  infoWindow.setContent(popup[0])
-			  infoWindow.open(map, this);
-			  infoWindow.marker = this
-			  
-			  activeAirportPopupInfoWindow = infoWindow
+			  this.bindPopup(popup[0], { maxWidth: 250, autoPan: false })
+			  this.openPopup()
+              activeAirportPopupInfoWindow = { popup: this.getPopup(), marker: this }
 			  
 			  if (activeAirline) {
 				  if (!activeAirline.headquarterAirport) {
@@ -748,17 +717,24 @@ function addMarkers(airports) {
 			  
 		  });
 
-		  marker.addListener('mouseover', function(event) {
+		  marker.on('mouseover', function(event) {
                this.setOpacity(0.9)
             })
-            marker.addListener('mouseout', function(event) {
-                if (infoWindow.marker != this) {
+            marker.on('mouseout', function(event) {
+                if (!activeAirportPopupInfoWindow || activeAirportPopupInfoWindow.marker != this) {
                     this.setOpacity(originalOpacity)
                 }
             })
 
+          marker.on('popupclose', function() {
+              if (activeAirportPopupInfoWindow && activeAirportPopupInfoWindow.marker === this) {
+                  activeAirportPopupInfoWindow = undefined
+              }
+              this.setOpacity(originalOpacity)
+          })
 
-		  marker.setVisible(isShowMarker(marker, currentZoom))
+
+		  setLeafletLayerVisibility(marker, isShowMarker(marker, currentZoom))
 
 
 		  resultMarkers[airportInfo.id] = marker
@@ -774,16 +750,13 @@ function planToAirportFromInfoWindow() {
 
 function removeMarkers() {
 	$.each(markers, function(key, marker) {
-		marker.setMap(null)
+		setLeafletLayerVisibility(marker, false)
 	});
 	markers = {}
 }
 
 function addCityMarkers(airportMap, airport) {
 	var cities = airport.citiesServed
-	var infoWindow = new google.maps.InfoWindow({
-		maxWidth : 500
-	})
 	var cityMarkerIcon = $("#airportMap").data("cityMarker")
 	var townMarkerIcon = $("#airportMap").data("townMarker")
 	var villageMarkerIcon = $("#airportMap").data("villageMarker")
@@ -803,18 +776,16 @@ function addCityMarkers(airportMap, airport) {
 		} else {
 			icon = villageMarkerIcon
 		}
-		var position = {lat: city.latitude, lng: city.longitude};
-		  var marker = new google.maps.Marker({
-			    position: position,
-			    map: airportMap,
-			    title: city.name,
-			    cityInfo : city,
-			    icon : icon
-			  });
+        var marker = L.marker([city.latitude, city.longitude], {
+            title: city.name,
+            cityInfo: city,
+            icon: createLeafletIcon(icon, { size: [16, 16], anchor: [8, 8] })
+        })
+        marker.__mapRef = airportMap
+        marker.addTo(airportMap)
 		  airportMapMarkers.push(marker)
 		  
-		  marker.addListener('click', function() {
-			  infoWindow.close();
+		  marker.on('click', function() {
 			  var city = this.cityInfo
 			  $("#cityPopupName").text(city.name)
 			  $("#cityPopupPopulation").text(commaSeparateNumber(city.population))
@@ -844,8 +815,8 @@ function addCityMarkers(airportMap, airport) {
 
 			var popup = $("#cityPopup").clone()
             popup.show()
-            infoWindow.setContent(popup[0])
-			infoWindow.open(airportMap, this);
+            this.bindPopup(popup[0], { maxWidth: 500, autoPan: false })
+			this.openPopup()
 			  
 			  
 			/////////////////////!!!!!!!!!!!!!!!
@@ -1102,8 +1073,8 @@ function toggleChampionMap() {
             if (marker.championIcon) {
                 marker.previousIcon = marker.icon
                 marker.previousTitle = marker.title
-                //marker.setIcon(marker.championIcon)
                 marker.setIcon(marker.championIcon)
+                marker.icon = marker.championIcon
                 var title = marker.title + " - " + marker.championAirlineName
         //        google.maps.event.clearListeners(marker, 'mouseover');
         //        google.maps.event.clearListeners(marker, 'mouseout');
@@ -1111,21 +1082,30 @@ function toggleChampionMap() {
                     addContestedMarker(marker)
                     title += " (contested by " + marker.contested + ")"
                 }
-                marker.setTitle(title)
+                marker.title = title
+                marker.options.title = title
+                if (marker._icon) {
+                    marker._icon.title = title
+                }
             } else {
-                marker.setVisible(false)
+                setLeafletLayerVisibility(marker, false)
             }
         } else {
 
             if (marker.championIcon) {
-                marker.setTitle(marker.previousTitle)
+                marker.title = marker.previousTitle
+                marker.options.title = marker.previousTitle
+                if (marker._icon) {
+                    marker._icon.title = marker.previousTitle
+                }
                 marker.setIcon(marker.previousIcon)
+                marker.icon = marker.previousIcon
             }
             while (contestedMarkers.length > 0) {
                 var contestedMarker = contestedMarkers.pop()
-                contestedMarker.setMap(null)
+                setLeafletLayerVisibility(contestedMarker, false)
             }
-            marker.setVisible(isShowMarker(marker, zoom))
+            setLeafletLayerVisibility(marker, isShowMarker(marker, zoom))
             updateAirportMarkers(activeAirline)
         }
     })
@@ -1133,16 +1113,14 @@ function toggleChampionMap() {
 }
 
 function addContestedMarker(airportMarker) {
-    var contestedMarker = new google.maps.Marker({
-        position: airportMarker.getPosition(),
-        map,
+    var contestedMarker = L.marker(airportMarker.getLatLng(), {
         title: "Contested",
-        icon: { anchor: new google.maps.Point(-5,15), url: "assets/images/icons/fire.png" },
-        zIndex: 500
-      });
-    //marker.setVisible(isShowMarker(airportMarker, zoom))
-    contestedMarker.bindTo("visible", airportMarker)
-    contestedMarker.setZIndex(airportMarker.getZIndex() + 1)
+        icon: createLeafletIcon("assets/images/icons/fire.png", { size: [16, 16], anchor: [-5, 15] })
+    })
+    contestedMarker.__mapRef = map
+    contestedMarker.setZIndexOffset(airportMarker.getZIndexOffset() + 1)
+    airportMarker.contestedMarker = contestedMarker
+    setLeafletLayerVisibility(contestedMarker, map.hasLayer(airportMarker))
     contestedMarkers.push(contestedMarker)
 }
 
@@ -1151,18 +1129,19 @@ function updateAirportBaseMarkers(newBaseAirports, relatedFlightPaths) {
     //reset baseMarkers
     $.each(baseMarkers, function(index, marker) {
         marker.setIcon(marker.originalIcon)
+        marker.icon = marker.originalIcon
         marker.isBase = false
-        marker.setVisible(isShowMarker(marker, map.getZoom()))
+        setLeafletLayerVisibility(marker, isShowMarker(marker, map.getZoom()))
         marker.baseInfo = undefined
-        google.maps.event.clearListeners(marker, 'mouseover');
-        google.maps.event.clearListeners(marker, 'mouseout');
+        marker.off('mouseover')
+        marker.off('mouseout')
 
     })
     baseMarkers = []
-    var headquarterMarkerIcon = $("#map").data("headquarterMarker")
-    var baseMarkerIcon = $("#map").data("baseMarker")
-	var baseAllianceIcon = $("#map").data("baseAllianceMarker")
-	var baseAllianceHQIcon = $("#map").data("baseAlliancehqMarker")
+    var headquarterMarkerIcon = createLeafletIcon($("#map").data("headquarterMarker"), { size: [32, 37], anchor: [16, 37] })
+    var baseMarkerIcon = createLeafletIcon($("#map").data("baseMarker"), { size: [32, 37], anchor: [16, 37] })
+	var baseAllianceIcon = createLeafletIcon($("#map").data("baseAllianceMarker"), { size: [32, 37], anchor: [16, 37] })
+	var baseAllianceHQIcon = createLeafletIcon($("#map").data("baseAlliancehqMarker"), { size: [32, 37], anchor: [16, 37] })
 
     $.each(newBaseAirports, function(key, baseAirport) {
 		if(!baseAirport) return;
@@ -1171,43 +1150,47 @@ function updateAirportBaseMarkers(newBaseAirports, relatedFlightPaths) {
 		if(baseAirport.airlineId !== activeAirline.id) {
 			if (baseAirport.headquarter) {
 				marker.setIcon(baseAllianceHQIcon)
+                marker.icon = baseAllianceHQIcon
 			} else {
 				marker.setIcon(baseAllianceIcon)
+                marker.icon = baseAllianceIcon
 			}
 		}
 
 		else {
 			if (baseAirport.headquarter) {
 				marker.setIcon(headquarterMarkerIcon)
+                marker.icon = headquarterMarkerIcon
 			} else {
 				marker.setIcon(baseMarkerIcon)
+                marker.icon = baseMarkerIcon
 			}
 		}
-        marker.setZIndex(999)
+        marker.setZIndexOffset(999)
         marker.isBase = true
-        marker.setVisible(true)
+        setLeafletLayerVisibility(marker, true)
         marker.baseInfo = baseAirport
-        var originalOpacity = marker.getOpacity()
-        marker.addListener('mouseover', function(event) {
+        var originalOpacity = marker.options.opacity
+        marker.on('mouseover', function(event) {
                     $.each(relatedFlightPaths, function(linkId, pathEntry) {
                         var path = pathEntry.path
                         var link = pathEntry.path.link
-                        if (!$(path).data("originalOpacity")) {
-                            $(path).data("originalOpacity", path.strokeOpacity)
+                        if (path.originalOpacity === undefined) {
+                            path.originalOpacity = path.options.opacity
                         }
                         if (link.fromAirportId != baseAirport.airportId || link.airlineId != baseAirport.airlineId) {
-                            path.setOptions({ strokeOpacity : 0.1 })
+                            path.setStyle({ opacity: 0.1 })
                         } else {
-                            path.setOptions({ strokeOpacity : 0.8 })
+                            path.setStyle({ opacity: 0.8 })
                         }
                     })
                 })
-        marker.addListener('mouseout', function(event) {
+        marker.on('mouseout', function(event) {
             $.each(relatedFlightPaths, function(linkId, pathEntry) {
                 var path = pathEntry.path
-                var originalOpacity = $(path).data("originalOpacity")
+                var originalOpacity = path.originalOpacity
                 if (originalOpacity !== undefined) {
-                    path.setOptions({ strokeOpacity : originalOpacity })
+                    path.setStyle({ opacity: originalOpacity })
                 }
             })
         })
@@ -1241,7 +1224,7 @@ function toggleAirportLinksView() {
 
 function closeAirportInfoPopup() {
     if (activeAirportPopupInfoWindow) {
-        activeAirportPopupInfoWindow.close(map)
+        activeAirportPopupInfoWindow.popup.remove()
         if (activeAirportPopupInfoWindow.marker) {
             activeAirportPopupInfoWindow.marker.setOpacity(0.7)
         }
@@ -1302,8 +1285,8 @@ function toggleAirportLinks(airport) {
 
 function drawAirportLinkPath(localAirport, details) {
     var remoteAirport = details.remoteAirport
-    var from = new google.maps.LatLng({lat: localAirport.latitude, lng: localAirport.longitude})
-	var to = new google.maps.LatLng({lat: remoteAirport.latitude, lng: remoteAirport.longitude})
+    var from = L.latLng(localAirport.latitude, localAirport.longitude)
+	var to = L.latLng(remoteAirport.latitude, remoteAirport.longitude)
 	var pathKey = remoteAirport.id
 
     var totalCapacity = details.capacity.total
@@ -1315,41 +1298,38 @@ function drawAirportLinkPath(localAirport, details) {
         opacity = 0.8
     }
 
-	var airportLinkPath = new google.maps.Polyline({
-			 geodesic: true,
-		     strokeColor: "#DC83FC",
-		     strokeOpacity: opacity,
-		     strokeWeight: 2,
-		     path: [from, to],
-		     zIndex : 1100,
-		     map: map,
-		});
+	var airportLinkPath = L.polyline([from, to], {
+        color: "#DC83FC",
+        opacity: opacity,
+        weight: 2
+    })
+    airportLinkPath.addTo(map)
+    airportLinkPath.__mapRef = map
 		
 	var fromAirport = getAirportText(localAirport.city, localAirport.iata)
 	var toAirport = getAirportText(remoteAirport.city, remoteAirport.iata)
 	
 	
-	shadowPath = new google.maps.Polyline({
-		 geodesic: true,
-	     strokeColor: "#DC83FC",
-	     strokeOpacity: 0.0001,
-	     strokeWeight: 25,
-	     path: [from, to],
-	     zIndex : 401,
-	     fromAirport : fromAirport,
-	     fromCountry : localAirport.countryCode, 
-	     toAirport : toAirport,
-	     toCountry : remoteAirport.countryCode,
-	     details: details,
-	     map: map,
-	});
+	shadowPath = L.polyline([from, to], {
+        color: "#DC83FC",
+        opacity: 0.001,
+        weight: 25,
+        interactive: true
+    })
+    shadowPath.fromAirport = fromAirport
+    shadowPath.fromCountry = localAirport.countryCode
+    shadowPath.toAirport = toAirport
+    shadowPath.toCountry = remoteAirport.countryCode
+    shadowPath.details = details
+    shadowPath.addTo(map)
+    shadowPath.__mapRef = map
 	polylines.push(airportLinkPath)
     polylines.push(shadowPath)
 	
 	airportLinkPath.shadowPath = shadowPath
 	
-	var infowindow;
-	shadowPath.addListener('mouseover', function(event) {
+	var infoPopup = L.popup({ maxWidth: 400, autoPan: false, closeButton: false })
+	shadowPath.on('mouseover', function(event) {
 	    highlightPath(airportLinkPath, false)
 		$("#airportLinkPopupFrom").html(getCountryFlagImg(this.fromCountry) + this.fromAirport)
 		$("#airportLinkPopupTo").html(getCountryFlagImg(this.toCountry) + this.toAirport)
@@ -1362,20 +1342,15 @@ function drawAirportLinkPath(localAirport, details) {
 		    $("#airportLinkOperators").append($operatorDiv)
 		})
 
-
-		infowindow = new google.maps.InfoWindow({
-             maxWidth : 400
-             });
         var popup = $("#airportLinkPopup").clone()
         popup.show()
-        infowindow.setContent(popup[0])
-		
-		infowindow.setPosition(event.latLng);
-		infowindow.open(map);
+        infoPopup.setContent(popup[0])
+		infoPopup.setLatLng(event.latlng)
+		infoPopup.openOn(map)
 	})		
-	shadowPath.addListener('mouseout', function(event) {
+	shadowPath.on('mouseout', function(event) {
 	    unhighlightPath(airportLinkPath)
-		infowindow.close()
+		map.closePopup(infoPopup)
 	})
 	
 	airportLinkPaths[pathKey] = airportLinkPath
@@ -1383,8 +1358,8 @@ function drawAirportLinkPath(localAirport, details) {
 
 function clearAirportLinkPaths() {
 	$.each(airportLinkPaths, function(key, airportLinkPath) {
-		airportLinkPath.setMap(null)
-		airportLinkPath.shadowPath.setMap(null)
+		setLeafletLayerVisibility(airportLinkPath, false)
+		setLeafletLayerVisibility(airportLinkPath.shadowPath, false)
 	})
 	
 	airportLinkPaths = {}
@@ -1417,7 +1392,7 @@ function getAirportIcon(airportInfo) {
     } else {
       icon = largeAirportMarkerIcon
     }
-    return icon
+    return createLeafletIcon(icon, { size: [32, 37], anchor: [16, 37] })
 }
 function hideAppealBreakdown() {
     $('#appealBonusDetailsTooltip').hide()

--- a/airline-web/public/javascripts/alliance.js
+++ b/airline-web/public/javascripts/alliance.js
@@ -752,7 +752,7 @@ function showAllianceMap() {
 				var airportMarkers = updateAirportBaseMarkers(allianceBases, alliancePaths)
 				//now add extra listener for alliance airports
 				$.each(airportMarkers, function(key, marker) {
-                        marker.addListener('mouseover', function(event) {
+                        marker.on('mouseover', function(event) {
                             closeAlliancePopups()
                             var baseInfo = marker.baseInfo
                             $("#allianceBasePopup .city").html(getCountryFlagImg(baseInfo.countryCode) + "&nbsp;" + baseInfo.city)
@@ -761,15 +761,13 @@ function showAllianceMap() {
                             $("#allianceBasePopup .airlineName").html(getAirlineLogoImg(baseInfo.airlineId) + "&nbsp;" + baseInfo.airlineName)
                             $("#allianceBasePopup .baseScale").html(baseInfo.scale)
 
-                            var infoWindow = new google.maps.InfoWindow({ maxWidth : 1200});
                             var popup = $("#allianceBasePopup").clone()
                             popup.show()
-                            infoWindow.setContent(popup[0])
-                            //infoWindow.setPosition(event.latLng);
-                            infoWindow.open(map, marker);
-                            map.allianceBasePopup = infoWindow
+                            marker.bindPopup(popup[0], { maxWidth: 1200, autoPan: false, closeButton: false })
+                            marker.openPopup()
+                            map.allianceBasePopup = marker.getPopup()
                         })
-                        marker.addListener('mouseout', function(event) {
+                        marker.on('mouseout', function(event) {
                             closeAlliancePopups()
                         })
                     })
@@ -777,7 +775,7 @@ function showAllianceMap() {
 
 				switchMap();
 				$("#worldMapCanvas").data("initCallback", function() { //if go back to world map, re-init the map
-				        map.controls[google.maps.ControlPosition.TOP_CENTER].clear()
+				        clearLeafletControlContainer(map, "topcenter")
 				        clearAllPaths()
                         updateAirportMarkers(activeAirline)
                         updateLinksInfo() //redraw all flight paths
@@ -800,15 +798,16 @@ function showAllianceMap() {
 }
 
 function addExitButton() {
-    if (map.controls[google.maps.ControlPosition.TOP_CENTER].getLength() > 0) {
-        map.controls[google.maps.ControlPosition.TOP_CENTER].clear()
+    var container = getLeafletControlContainer(map, "topcenter")
+    if (container && container.childElementCount > 0) {
+        clearLeafletControlContainer(map, "topcenter")
     }
-    map.controls[google.maps.ControlPosition.TOP_CENTER].push(createMapButton(map, 'Exit Alliance Flight Map', 'hideAllianceMap()', 'hideAllianceMapButton')[0]);
+    addLeafletControlElement(map, "topcenter", createMapButton(map, 'Exit Alliance Flight Map', 'hideAllianceMap()', 'hideAllianceMapButton')[0])
 }
 
 function drawAllianceLink(link) {
-	var from = new google.maps.LatLng({lat: link.fromLatitude, lng: link.fromLongitude})
-	var to = new google.maps.LatLng({lat: link.toLatitude, lng: link.toLongitude})
+	var from = L.latLng(link.fromLatitude, link.fromLongitude)
+	var to = L.latLng(link.toLatitude, link.toLongitude)
 	//var pathKey = link.id
 	
 	var strokeColor = airlineColors[link.airlineId]
@@ -826,40 +825,35 @@ function drawAllianceLink(link) {
         strokeOpacity = maxOpacity
     }
 		
-	var linkPath = new google.maps.Polyline({
-			 geodesic: true,
-		     strokeColor: strokeColor,
-		     strokeOpacity: strokeOpacity,
-		     strokeWeight: 2,
-		     path: [from, to],
-		     zIndex : 90,
-		     link : link
-		});
+	var linkPath = L.polyline([from, to], {
+        color: strokeColor,
+        opacity: strokeOpacity,
+        weight: 2
+    })
+    linkPath.link = link
 		
 	var fromAirport = getAirportText(link.fromAirportCity, link.fromAirportCode)
 	var toAirport = getAirportText(link.toAirportCity, link.toAirportCode)
 	
 	
-	shadowPath = new google.maps.Polyline({
-		 geodesic: true,
-	     strokeColor: strokeColor,
-	     strokeOpacity: 0.0001,
-	     strokeWeight: 25,
-	     path: [from, to],
-	     zIndex : 100,
-	     fromAirport : fromAirport,
-	     fromCountry : link.fromCountryCode, 
-	     toAirport : toAirport,
-	     toCountry : link.toCountryCode,
-	     capacity : link.capacity.total,
-	     airlineName : link.airlineName,
-	     airlineId : link.airlineId
-	});
+	shadowPath = L.polyline([from, to], {
+        color: strokeColor,
+        opacity: 0.001,
+        weight: 25,
+        interactive: true
+    })
+    shadowPath.fromAirport = fromAirport
+    shadowPath.fromCountry = link.fromCountryCode
+    shadowPath.toAirport = toAirport
+    shadowPath.toCountry = link.toCountryCode
+    shadowPath.capacity = link.capacity.total
+    shadowPath.airlineName = link.airlineName
+    shadowPath.airlineId = link.airlineId
 	
 	linkPath.shadowPath = shadowPath
 	
 
-	shadowPath.addListener('mouseover', function(event) {
+	shadowPath.on('mouseover', function(event) {
 	    if (!map.allianceBasePopup) { //only do this if it is not hovered over base icon. This is a workaround as zIndex does not work - hovering over base icon triggers onmouseover event on the link below the icon
             $("#linkPopupFrom").html(getCountryFlagImg(this.fromCountry) + "&nbsp;" + this.fromAirport)
             $("#linkPopupTo").html(getCountryFlagImg(this.toCountry) + "&nbsp;" + this.toAirport)
@@ -867,24 +861,23 @@ function drawAllianceLink(link) {
             $("#linkPopupAirline").html(getAirlineLogoImg(this.airlineId) + "&nbsp;" + this.airlineName)
 
 
-            var infowindow = new google.maps.InfoWindow({
-                 maxWidth : 1200});
-
             var popup = $("#linkPopup").clone()
             popup.show()
-            infowindow.setContent(popup[0])
-
-            infowindow.setPosition(event.latLng);
-            infowindow.open(map);
-            map.allianceLinkPopup = infowindow
+            var infoPopup = L.popup({ maxWidth: 1200, autoPan: false, closeButton: false })
+            infoPopup.setContent(popup[0])
+            infoPopup.setLatLng(event.latlng)
+            infoPopup.openOn(map)
+            map.allianceLinkPopup = infoPopup
         }
 	})		
-	shadowPath.addListener('mouseout', function(event) {
+	shadowPath.on('mouseout', function(event) {
         closeAllianceLinkPopup()
 	})
 	
-	linkPath.setMap(map)
-	linkPath.shadowPath.setMap(map)
+	linkPath.addTo(map)
+	linkPath.__mapRef = map
+	linkPath.shadowPath.addTo(map)
+	linkPath.shadowPath.__mapRef = map
 	polylines.push(linkPath)
 	polylines.push(linkPath.shadowPath)
 
@@ -1099,8 +1092,7 @@ function selectAllianceMission(mission, callback) {
 
 function closeAlliancePopups() {
     if (map.allianceBasePopup) {
-        map.allianceBasePopup.close()
-        map.allianceBasePopup.setMap(null)
+        map.closePopup(map.allianceBasePopup)
         map.allianceBasePopup = undefined
     }
     closeAllianceLinkPopup()
@@ -1108,15 +1100,14 @@ function closeAlliancePopups() {
 
 function closeAllianceLinkPopup() {
     if (map.allianceLinkPopup) {
-        map.allianceLinkPopup.close()
-        map.allianceLinkPopup.setMap(null)
+        map.closePopup(map.allianceLinkPopup)
         map.allianceLinkPopup = undefined
     }
 }
 
 
 function hideAllianceMap() {
-    map.controls[google.maps.ControlPosition.TOP_CENTER].clear()
+    clearLeafletControlContainer(map, "topcenter")
     clearAllPaths()
     updateAirportBaseMarkers([]) //revert base markers
     closeAlliancePopups()

--- a/airline-web/public/javascripts/campaign.js
+++ b/airline-web/public/javascripts/campaign.js
@@ -10,14 +10,15 @@ function showCampaignModal() {
     })
 
     if (!campaignMap) {
-     campaignMap = new google.maps.Map($('#campaignModal .campaignMap')[0], {
-                                              //gestureHandling: 'none',
-                                              disableDefaultUI: true,
-                                              scrollwheel: false,
-                                              draggable: true,
-                                              panControl: true,
-                                              styles: getMapStyles()
-                                          })
+     campaignMap = L.map($('#campaignModal .campaignMap')[0], {
+         zoomControl: false,
+         scrollWheelZoom: false,
+         dragging: true,
+         doubleClickZoom: false,
+         boxZoom: false,
+         keyboard: false
+     })
+     applyMapStyle(campaignMap)
     }
 
     updateAirlineDelegateStatus($('#campaignModal div.delegateStatus'), function(delegateInfo) {
@@ -230,35 +231,33 @@ var campaignMap
 var campaignMapElements = []
 
 function populateCampaignMap(principalAirport, campaignArea, candidateArea, radius) {
-    $.each(campaignMapElements, function() { this.setMap(null)})
+    $.each(campaignMapElements, function() { setLeafletLayerVisibility(this, false, campaignMap) })
     campaignMapElements = []
 
     //+ 200 to include candidate area * 1000 to convert to meters, * 2 to convert to diameter, * 1.2 to make in a slight bigger than what needs to be
     var zoom = getGoogleZoomLevel((radius + 200) * 1000 * 2 * 1.2, $('#campaignModal .campaignMap'), principalAirport.latitude)
-    campaignMap.setZoom(zoom)
+    campaignMap.setView([principalAirport.latitude, principalAirport.longitude], zoom)
 
-    campaignMap.setCenter({lat: principalAirport.latitude, lng: principalAirport.longitude}); //this would eventually trigger an idle
-
-    var airportMapCircle = new google.maps.Circle({
-                center: {lat: principalAirport.latitude, lng: principalAirport.longitude},
-                radius: radius * 1000, //in meter
-                strokeColor: "#32CF47",
-                strokeOpacity: 0.2,
-                strokeWeight: 2,
-                fillColor: "#32CF47",
-                fillOpacity: 0.3,
-                map: campaignMap
-            });
+    var airportMapCircle = L.circle([principalAirport.latitude, principalAirport.longitude], {
+        radius: radius * 1000, //in meter
+        color: "#32CF47",
+        opacity: 0.2,
+        weight: 2,
+        fillColor: "#32CF47",
+        fillOpacity: 0.3
+    })
+    airportMapCircle.__mapRef = campaignMap
+    airportMapCircle.addTo(campaignMap)
     campaignMapElements.push(airportMapCircle)
     populateCampaignAirportMarkers(campaignMap, campaignArea, true)
     populateCampaignAirportMarkers(campaignMap, candidateArea, false)
-    google.maps.event.addListenerOnce(campaignMap, 'idle', function() {
+    campaignMap.whenReady(function() {
         setTimeout(function() { //set a timeout here, otherwise it might not render part of the map...
-            campaignMap.setCenter({lat: principalAirport.latitude, lng: principalAirport.longitude}); //this would eventually trigger an idle
-            google.maps.event.trigger(campaignMap, 'resize'); //this refreshes the map
+            campaignMap.setView([principalAirport.latitude, principalAirport.longitude], zoom)
+            campaignMap.invalidateSize()
             console.log('resize')
-        }, 2000);
-    });
+        }, 2000)
+    })
 }
 
 function populateCampaignAirportMarkers(campaignMap, airports, hasCoverage) {
@@ -267,36 +266,27 @@ function populateCampaignAirportMarkers(campaignMap, airports, hasCoverage) {
         if (hasCoverage) {
             icon = getAirportIcon(airport)
         } else {
-            icon = $("#map").data("disabledAirportMarker")
+            icon = createLeafletIcon($("#map").data("disabledAirportMarker"), { size: [32, 37], anchor: [16, 37] })
         }
-        var position = {lat: airport.latitude, lng: airport.longitude};
-          var marker = new google.maps.Marker({
-                position: position,
-                map: campaignMap,
-                airport: airport,
-                icon : icon
-              });
+        var marker = L.marker([airport.latitude, airport.longitude], {
+            airport: airport,
+            icon: icon
+        })
+        marker.__mapRef = campaignMap
+        marker.addTo(campaignMap)
 
-            var infowindow
-           	marker.addListener('mouseover', function(event) {
-           		$("#campaignAirportPopup .airportName").text(getAirportText(airport.city, airport.iata))
-           		$("#campaignAirportPopup .airportPopulation").text(airport.population)
-           		infowindow = new google.maps.InfoWindow({
-           		       disableAutoPan : true
-                 });
-
-                 var popup = $("#campaignAirportPopup").clone()
-                 popup.show()
-                 infowindow.setContent(popup[0])
-
-
-           		infowindow.open(campaignMap, marker);
-           	})
-           	marker.addListener('mouseout', function(event) {
-           		infowindow.close()
-           		infowindow.setMap(null)
-           	})
-           	campaignMapElements.push(marker)
+        marker.on('mouseover', function(event) {
+            $("#campaignAirportPopup .airportName").text(getAirportText(airport.city, airport.iata))
+            $("#campaignAirportPopup .airportPopulation").text(airport.population)
+            var popup = $("#campaignAirportPopup").clone()
+            popup.show()
+            this.bindPopup(popup[0], { autoPan: false, closeButton: false })
+            this.openPopup()
+        })
+        marker.on('mouseout', function(event) {
+            this.closePopup()
+        })
+        campaignMapElements.push(marker)
 
      })
 }

--- a/airline-web/public/javascripts/christmas.js
+++ b/airline-web/public/javascripts/christmas.js
@@ -194,11 +194,7 @@ function toggleChristmasMarker() {
 		document.getElementById('christmasMusic').pause()
 		$.each(flightMarkers, function(index, markersByLinkId) {
 			$.each(markersByLinkId.markers, function(index2, marker) {
-				marker.icon = {
-			        url: "assets/images/markers/dot.png",
-			        origin: new google.maps.Point(0, 0),
-			        anchor: new google.maps.Point(6, 6),
-			    };
+				marker.setIcon(createLeafletIcon("assets/images/markers/dot.png", { size: [12, 12], anchor: [6, 6] }))
 			})
 		})
 		$("body").removeClass('christmas')
@@ -266,7 +262,6 @@ function randomFlightMarker() {
 	})
 	return pickedImage
 }
-
 
 
 

--- a/airline-web/public/javascripts/event.js
+++ b/airline-web/public/javascripts/event.js
@@ -283,7 +283,7 @@ function populateCityVoteModal(candidates, votes, votingActive) {
         })
     })
 
-    $.each(olympicsMapElements, function() { this.setMap(null)})
+    $.each(olympicsMapElements, function() { setLeafletLayerVisibility(this, false) })
     olympicsMapElements = []
 
     table.find(".number-button").each(function(index) {
@@ -337,60 +337,51 @@ function populateOlympicsCityMap(map, candidateInfo) {
     } else {
         map.setZoom(7)
     }
-    map.setCenter({lat: principalAirport.latitude, lng: principalAirport.longitude}); //this would eventually trigger an idle
+    map.setView([principalAirport.latitude, principalAirport.longitude], map.getZoom())
 
-    var airportMapCircle = new google.maps.Circle({
-                center: {lat: principalAirport.latitude, lng: principalAirport.longitude},
-                radius: 80000, //in meter
-                strokeColor: "#32CF47",
-                strokeOpacity: 0.2,
-                strokeWeight: 2,
-                fillColor: "#32CF47",
-                fillOpacity: 0.3,
-                map: map
-            });
+    var airportMapCircle = L.circle([principalAirport.latitude, principalAirport.longitude], {
+        radius: 80000, //in meter
+        color: "#32CF47",
+        opacity: 0.2,
+        weight: 2,
+        fillColor: "#32CF47",
+        fillOpacity: 0.3
+    })
+    airportMapCircle.__mapRef = map
+    airportMapCircle.addTo(map)
     olympicsMapElements.push(airportMapCircle)
 
     $.each(candidateInfo.affectedAirports, function(index, airport) {
         var icon = getAirportIcon(airport)
-        var position = {lat: airport.latitude, lng: airport.longitude};
-          var marker = new google.maps.Marker({
-                position: position,
-                map: map,
-                airport: airport,
-                icon : icon
-              });
+        var marker = L.marker([airport.latitude, airport.longitude], {
+            airport: airport,
+            icon: icon
+        })
+        marker.__mapRef = map
+        marker.addTo(map)
 
-            var infowindow
-           	marker.addListener('mouseover', function(event) {
-           		$("#olympicAirportPopup .airportName").text(airport.name + "(" + airport.iata + ")")
-           		infowindow = new google.maps.InfoWindow({
-           		       maxWidth : 800,
-                       disableAutoPan : true
-                 });
-                 var popup = $("#olympicAirportPopup").clone()
-                 popup.show()
-                 infowindow.setContent(popup[0])
-
-
-           		infowindow.open(map, marker);
-           	})
-           	marker.addListener('mouseout', function(event) {
-           		infowindow.close()
-           		infowindow.setMap(null)
-           	})
-           	olympicsMapElements.push(marker)
+        marker.on('mouseover', function(event) {
+            $("#olympicAirportPopup .airportName").text(airport.name + "(" + airport.iata + ")")
+            var popup = $("#olympicAirportPopup").clone()
+            popup.show()
+            this.bindPopup(popup[0], { maxWidth: 800, autoPan: false, closeButton: false })
+            this.openPopup()
+        })
+        marker.on('mouseout', function(event) {
+            this.closePopup()
+        })
+        olympicsMapElements.push(marker)
 
      })
 
 
 
-    google.maps.event.addListenerOnce(map, 'idle', function() {
+    map.whenReady(function() {
         setTimeout(function() { //set a timeout here, otherwise it might not render part of the map...
-            map.setCenter({lat: principalAirport.latitude, lng: principalAirport.longitude}); //this would eventually trigger an idle
-            google.maps.event.trigger(map, 'resize'); //this refreshes the map
-        }, 2000);
-    });
+            map.setView([principalAirport.latitude, principalAirport.longitude], map.getZoom())
+            map.invalidateSize()
+        }, 2000)
+    })
 }
 
 function voteOlympicsCity(numberButton) {
@@ -443,11 +434,16 @@ var olympicsVoteMaps
 function initOlympicsVoteMaps(mapDivs) { //only called once, see https://stackoverflow.com/questions/10485582/what-is-the-proper-way-to-destroy-a-map-instance
     olympicsVoteMaps = []
 //    for (i = 0 ; i < mapDivs.length; i ++) {
-//        olympicsVoteMaps.push(new google.maps.Map(mapDivs[i][0], {
-//                        gestureHandling: 'none',
-//                        disableDefaultUI: true,
-//                        styles: getMapStyles()
-//                    }))
+//        var mapInstance = L.map(mapDivs[i][0], {
+//            zoomControl: false,
+//            scrollWheelZoom: false,
+//            dragging: false,
+//            doubleClickZoom: false,
+//            boxZoom: false,
+//            keyboard: false
+//        })
+//        applyMapStyle(mapInstance)
+//        olympicsVoteMaps.push(mapInstance)
 //    }
 }
 
@@ -655,4 +651,3 @@ function getOlympicsCountryRankingRow(rank, entry) {
     row.append("<div class='cell' style='text-align: right;'>" + Math.round(entry.percentage) + "%</div>")
 	return row
 }
-

--- a/airline-web/public/javascripts/heatmap.js
+++ b/airline-web/public/javascripts/heatmap.js
@@ -44,12 +44,12 @@ function closeHeatmap() {
 
 function clearHeatmap() {
     if (heatmapPositive) {
-        heatmapPositive.setMap(null)
+        map.removeLayer(heatmapPositive)
         heatmapPositive = undefined
     }
     if (heatmapNegative) {
-        heatmapNegative.setMap(null)
-        heatmapPositive = undefined
+        map.removeLayer(heatmapNegative)
+        heatmapNegative = undefined
     }
 }
 
@@ -115,9 +115,9 @@ function updateHeatmap(airlineId) {
             var heatmapNegativeData = []
             $.each(result.points, function(index, entry) {
               if (entry.weight >= 0) {
-                heatmapPositiveData.push({location: new google.maps.LatLng(entry.lat, entry.lng), weight: entry.weight})
+                heatmapPositiveData.push(entry)
               } else {
-                heatmapNegativeData.push({location: new google.maps.LatLng(entry.lat, entry.lng), weight: entry.weight * -1})
+                heatmapNegativeData.push({ lat: entry.lat, lng: entry.lng, weight: entry.weight * -1 })
               }
             })
 
@@ -131,27 +131,13 @@ function updateHeatmap(airlineId) {
             }
 
             if (heatmapPositiveData.length > 0) {
-                heatmapPositive = new google.maps.visualization.HeatmapLayer({
-                  data: heatmapPositiveData,
-                  dissipating: false,
-                  gradient: heatmapPositiveGradient,
-                  maxIntensity: result.maxIntensity,
-                  radius: 3
-                });
-
-                heatmapPositive.setMap(map);
+                heatmapPositive = buildHeatmapLayer(heatmapPositiveData, heatmapPositiveGradient, result.maxIntensity)
+                heatmapPositive.addTo(map)
             }
 
             if (heatmapNegativeData.length > 0) {
-                heatmapNegative = new google.maps.visualization.HeatmapLayer({
-                  data: heatmapNegativeData,
-                  dissipating: false,
-                  gradient: heatmapNegativeGradient,
-                  maxIntensity: result.maxIntensity,
-                  radius: 3
-                });
-
-                heatmapNegative.setMap(map);
+                heatmapNegative = buildHeatmapLayer(heatmapNegativeData, heatmapNegativeGradient, result.maxIntensity)
+                heatmapNegative.addTo(map)
             }
 
             updateHeatmapArrows(result.minDeltaCount, airlineId)
@@ -168,6 +154,31 @@ function updateHeatmap(airlineId) {
 //	    	$('body .loadingSpinner').hide()
 //	    }
     });
+}
+
+function buildHeatmapLayer(points, gradient, maxIntensity) {
+    var layerGroup = L.layerGroup()
+    var maxValue = maxIntensity || 1
+    $.each(points, function(index, entry) {
+        var intensity = Math.min(entry.weight, maxValue)
+        var color = getHeatmapColor(gradient, intensity, maxValue)
+        var opacity = Math.min(1, intensity / maxValue)
+        L.circle([entry.lat, entry.lng], {
+            radius: 30000,
+            color: color,
+            fillColor: color,
+            fillOpacity: opacity,
+            opacity: opacity,
+            weight: 0
+        }).addTo(layerGroup)
+    })
+    return layerGroup
+}
+
+function getHeatmapColor(gradient, intensity, maxIntensity) {
+    var ratio = maxIntensity > 0 ? intensity / maxIntensity : 0
+    var index = Math.min(gradient.length - 1, Math.floor(ratio * (gradient.length - 1)))
+    return gradient[index]
 }
 
 function updateHeatmapArrows(minDeltaCount, airlineId) {
@@ -241,4 +252,3 @@ function updateHeatmapArrows(minDeltaCount, airlineId) {
             })
         }
 }
-

--- a/airline-web/public/javascripts/link-history.js
+++ b/airline-web/public/javascripts/link-history.js
@@ -43,8 +43,8 @@ function showLinkHistoryView() {
 
 function loadLinkHistory(linkId) {
     $.each(historyPaths, function(index, path) { //clear all history path
-        path.setMap(null)
-        path.shadowPath.setMap(null)
+        setLeafletLayerVisibility(path, false)
+        setLeafletLayerVisibility(path.shadowPath, false)
     })
     historyPaths = {}
 	var linkInfo = loadedLinksById[linkId]
@@ -155,7 +155,7 @@ function toggleLinkHistoryDirection(showForward, routeDiv) {
 
 function hideLinkHistoryView() {
 	$.each(historyPaths, function(index, path) {
-	    path.setMap(null)
+	    setLeafletLayerVisibility(path, false)
 	})
     historyPaths = {}
 
@@ -170,46 +170,33 @@ function hideLinkHistoryView() {
 }
 
 function drawLinkHistoryPath(link, inverted, watchedLinkId, step) {
-	var from = new google.maps.LatLng({lat: link.fromLatitude, lng: link.fromLongitude})
-	var to = new google.maps.LatLng({lat: link.toLatitude, lng: link.toLongitude})
+	var from = L.latLng(link.fromLatitude, link.fromLongitude)
+	var to = L.latLng(link.toLatitude, link.toLongitude)
 	var pathKey = link.fromAirportId + "|"  + link.toAirportId + "|" + inverted
-
-	var lineSymbol = {
-	    path: google.maps.SymbolPath.FORWARD_OPEN_ARROW
-	};
 
 	var isWatchedLink = link.linkId == watchedLinkId
 
 	var relatedPath
 	if (!historyPaths[pathKey]) {
-		relatedPath = new google.maps.Polyline({
-			 geodesic: true,
-		     strokeColor: "#DC83FC",
-		     strokeOpacity: 0.8,
-		     strokeWeight: 2,
-		     path: [from, to],
-		     icons: [{
-			      icon: lineSymbol,
-			      offset: '50%'
-			    }],
-		     zIndex : 1100,
-		     inverted : inverted,
-		     watched : isWatchedLink,
-		     step : step
-		});
+		relatedPath = L.polyline([from, to], {
+            color: "#DC83FC",
+            opacity: 0.8,
+            weight: 2
+        })
+        relatedPath.inverted = inverted
+        relatedPath.watched = isWatchedLink
+        relatedPath.step = step
 
-		shadowPath = new google.maps.Polyline({
-			 geodesic: true,
-		     strokeOpacity: 0.0001,
-		     strokeWeight: 25,
-		     path: [from, to],
-		     zIndex : 401,
-		     inverted : inverted,
-		     link : link,
-		     thisAirlinePassengers : 0,
-		     thisAlliancePassengers : 0,
-		     otherAirlinePassengers : 0
-		});
+		shadowPath = L.polyline([from, to], {
+            opacity: 0.001,
+            weight: 25,
+            interactive: true
+        })
+        shadowPath.inverted = inverted
+        shadowPath.link = link
+        shadowPath.thisAirlinePassengers = 0
+        shadowPath.thisAlliancePassengers = 0
+        shadowPath.otherAirlinePassengers = 0
 
 		relatedPath.shadowPath = shadowPath
 
@@ -231,7 +218,7 @@ function clearHistoryFlightMarkers() {
     $.each(historyFlightMarkers, function(index, markersOnAStep) {
         $.each(markersOnAStep, function(index, marker) {
         //window.clearInterval(marker.animation)
-    	    marker.setMap(null)
+    	    setLeafletLayerVisibility(marker, false)
         })
     })
     historyFlightMarkers = []
@@ -252,8 +239,8 @@ function animateHistoryFlightMarkers(framesPerAnimation) {
             if (!marker.isActive) {
                 marker.isActive = true
                 marker.elapsedDuration = 0
-                marker.setPosition(marker.from)
-                marker.setMap(map)
+                marker.setLatLng(marker.from)
+                setLeafletLayerVisibility(marker, true)
             } else  {
                 marker.elapsedDuration += 1
 
@@ -261,8 +248,8 @@ function animateHistoryFlightMarkers(framesPerAnimation) {
                     marker.isActive = false
                     //console.log("next departure " + marker.nextDepartureFrame)
                 } else {
-                    var newPosition = google.maps.geometry.spherical.interpolate(marker.from, marker.to, marker.elapsedDuration / marker.totalDuration)
-                    marker.setPosition(newPosition)
+                    var newPosition = interpolateGreatCircle(marker.from, marker.to, marker.elapsedDuration / marker.totalDuration)
+                    marker.setLatLng(newPosition)
                 }
             }
   		})
@@ -282,7 +269,7 @@ function fadeOutMarkers(markers, animationInterval) {
     var animation = window.setInterval(function () {
         if (opacity <= 0) {
             $.each(markers, function(index, marker) {
-                marker.setMap(null)
+                setLeafletLayerVisibility(marker, false)
                 marker.setOpacity(1)
             })
             window.clearInterval(animation)
@@ -298,8 +285,8 @@ function fadeOutMarkers(markers, animationInterval) {
 
 function drawHistoryFlightMarker(line, framesPerAnimation, totalPassengers) {
 	if (currentAnimationStatus) {
-		var from = line.getPath().getAt(0)
-		var to = line.getPath().getAt(1)
+		var from = line.getLatLngs()[0]
+		var to = line.getLatLngs()[1]
 		var icon
         if (totalPassengers > 200) {
 	       icon = "dot-5.png"
@@ -313,22 +300,19 @@ function drawHistoryFlightMarker(line, framesPerAnimation, totalPassengers) {
            icon = "dot-1.png"
         }
 
-		var image = {
-	        url: "assets/images/markers/" + icon,
-	        origin: new google.maps.Point(0, 0),
-	        anchor: new google.maps.Point(6, 6),
-	    };
+		var image = createLeafletIcon("assets/images/markers/" + icon, { size: [12, 12], anchor: [6, 6] })
 
-        var marker = new google.maps.Marker({
-            position: from,
-            from : from,
-            to : to,
-            icon : image,
-            elapsedDuration : 0,
-            totalDuration : framesPerAnimation,
-            isActive: false,
-            clickable: false
-        });
+        var marker = L.marker(from, {
+            icon: image,
+            opacity: 1,
+            keyboard: false
+        })
+        marker.__mapRef = map
+        marker.from = from
+        marker.to = to
+        marker.elapsedDuration = 0
+        marker.totalDuration = framesPerAnimation
+        marker.isActive = false
 
         //flightMarkers.push(marker)
         var step = line.step
@@ -403,13 +387,15 @@ function showLinkHistory() {
          || (showOther && historyPath.shadowPath.otherAirlinePassengers))) {
             var totalPassengers = historyPath.shadowPath.thisAirlinePassengers + historyPath.shadowPath.thisAlliancePassengers + historyPath.shadowPath.otherAirlinePassengers
             if (totalPassengers < 100) {
-                var newOpacity = 0.2 + totalPassengers / 100 * (historyPath.strokeOpacity - 0.2)
+                var newOpacity = 0.2 + totalPassengers / 100 * (historyPath.options.opacity - 0.2)
                 if (!historyPath.watched) {
-                    historyPath.setOptions({strokeOpacity : newOpacity})
+                    historyPath.setStyle({ opacity: newOpacity })
                 }
             }
-            var infowindow;
-            historyPath.shadowPath.addListener('mouseover', function(event) {
+            var infoPopup = L.popup({ maxWidth: 400, autoPan: false, closeButton: false })
+            historyPath.shadowPath.off('mouseover')
+            historyPath.shadowPath.off('mouseout')
+            historyPath.shadowPath.on('mouseover', function(event) {
                 var link = this.link
 
                 $("#linkHistoryPopupFrom").html(getCountryFlagImg(link.fromCountryCode) + getAirportText(link.fromAirportCity, link.fromAirportCode))
@@ -428,20 +414,16 @@ function showLinkHistory() {
                     $("#linkHistoryOtherAirlinePassengers").closest(".table-row").hide()
                  }
 
-                infowindow = new google.maps.InfoWindow({
-                     maxWidth : 400});
-
                 var popup = $("#linkHistoryPopup").clone()
     			popup.show()
-                infowindow.setContent(popup[0])
-
-                infowindow.setPosition(event.latLng);
-                infowindow.open(map);
+                infoPopup.setContent(popup[0])
+                infoPopup.setLatLng(event.latlng)
+                infoPopup.openOn(map)
 
                 highlightPath(historyPath, false)
             })
-            historyPath.shadowPath.addListener('mouseout', function(event) {
-                infowindow.close()
+            historyPath.shadowPath.on('mouseout', function(event) {
+                map.closePopup(infoPopup)
                 if (!historyPath.watched) { //do not unhighlight if it's watched link
                     unhighlightPath(historyPath)
                 }
@@ -449,11 +431,11 @@ function showLinkHistory() {
 
 
             if (historyPath.shadowPath.thisAirlinePassengers > 0) {
-                historyPath.setOptions({strokeColor: "#DC83FC"})
+                historyPath.setStyle({ color: "#DC83FC" })
             } else if (showAlliance && historyPath.shadowPath.thisAlliancePassengers > 0) {
-                historyPath.setOptions({strokeColor: "#E28413"})
+                historyPath.setStyle({ color: "#E28413" })
             } else {
-                historyPath.setOptions({strokeColor: "#888888"})
+                historyPath.setStyle({ color: "#888888" })
             }
 
 
@@ -465,13 +447,13 @@ function showLinkHistory() {
                 drawHistoryFlightMarker(historyPath, framesPerAnimation, totalPassengers)
             }
 
-            historyPath.setMap(map)
-            historyPath.shadowPath.setMap(map)
+            setLeafletLayerVisibility(historyPath, true)
+            setLeafletLayerVisibility(historyPath.shadowPath, true)
             polylines.push(historyPath)
             polylines.push(historyPath.shadowPath)
          } else {
-            historyPath.setMap(null)
-            historyPath.shadowPath.setMap(null)
+            setLeafletLayerVisibility(historyPath, false)
+            setLeafletLayerVisibility(historyPath.shadowPath, false)
          }
     })
     if (showAnimation) {
@@ -479,4 +461,3 @@ function showLinkHistory() {
     }
 
 }
-

--- a/airline-web/public/javascripts/main.js
+++ b/airline-web/public/javascripts/main.js
@@ -13,6 +13,118 @@ var polylines = []
 var airports = undefined
 var gameConstants
 var notes = {}
+var mapControlContainers = {}
+
+function createLeafletIcon(iconUrl, options) {
+    if (!iconUrl) {
+        return undefined
+    }
+    var size = options && options.size ? options.size : [32, 37]
+    var anchor = options && options.anchor ? options.anchor : [size[0] / 2, size[1]]
+    var popupAnchor = options && options.popupAnchor ? options.popupAnchor : [0, -size[1] / 2]
+    return L.icon({
+        iconUrl: iconUrl,
+        iconSize: size,
+        iconAnchor: anchor,
+        popupAnchor: popupAnchor
+    })
+}
+
+function setLeafletLayerVisibility(layer, visible, mapInstance) {
+    if (!layer) {
+        return
+    }
+    var targetMap = mapInstance || layer.__mapRef || map
+    if (!targetMap) {
+        return
+    }
+    if (visible) {
+        if (!targetMap.hasLayer(layer)) {
+            layer.addTo(targetMap)
+        }
+    } else if (targetMap.hasLayer(layer)) {
+        targetMap.removeLayer(layer)
+    }
+}
+
+function getLeafletControlContainer(mapInstance, position) {
+    if (!mapInstance) {
+        return null
+    }
+    mapInstance._customControlContainers = mapInstance._customControlContainers || {}
+    if (mapInstance._customControlContainers[position]) {
+        return mapInstance._customControlContainers[position]
+    }
+
+    var container
+    if (position === "topcenter") {
+        container = L.DomUtil.create("div", "leaflet-control custom-map-controls")
+        container.style.position = "absolute"
+        container.style.top = "10px"
+        container.style.left = "50%"
+        container.style.transform = "translateX(-50%)"
+        mapInstance.getContainer().appendChild(container)
+        L.DomEvent.disableClickPropagation(container)
+    } else {
+        var control = L.control({ position: position })
+        control.onAdd = function() {
+            var innerContainer = L.DomUtil.create("div", "leaflet-control custom-map-controls")
+            L.DomEvent.disableClickPropagation(innerContainer)
+            return innerContainer
+        }
+        control.addTo(mapInstance)
+        container = control.getContainer()
+    }
+
+    mapInstance._customControlContainers[position] = container
+    return container
+}
+
+function clearLeafletControlContainer(mapInstance, position) {
+    var container = getLeafletControlContainer(mapInstance, position)
+    if (!container) {
+        return
+    }
+    while (container.firstChild) {
+        container.removeChild(container.firstChild)
+    }
+}
+
+function addLeafletControlElement(mapInstance, position, element, index) {
+    var container = getLeafletControlContainer(mapInstance, position)
+    if (!container || !element) {
+        return
+    }
+    if (index === undefined || index < 0 || index >= container.children.length) {
+        container.appendChild(element)
+        return
+    }
+    container.insertBefore(element, container.children[index])
+}
+
+function interpolateGreatCircle(from, to, fraction) {
+    var lat1 = (from.lat || from.lat()) * Math.PI / 180
+    var lon1 = (from.lng || from.lng()) * Math.PI / 180
+    var lat2 = (to.lat || to.lat()) * Math.PI / 180
+    var lon2 = (to.lng || to.lng()) * Math.PI / 180
+
+    var sinLatDiff = Math.sin((lat2 - lat1) / 2)
+    var sinLonDiff = Math.sin((lon2 - lon1) / 2)
+    var angularDistance = 2 * Math.asin(Math.sqrt(sinLatDiff * sinLatDiff + Math.cos(lat1) * Math.cos(lat2) * sinLonDiff * sinLonDiff))
+    if (!angularDistance) {
+        return L.latLng(from.lat || from.lat(), from.lng || from.lng())
+    }
+
+    var a = Math.sin((1 - fraction) * angularDistance) / Math.sin(angularDistance)
+    var b = Math.sin(fraction * angularDistance) / Math.sin(angularDistance)
+    var x = a * Math.cos(lat1) * Math.cos(lon1) + b * Math.cos(lat2) * Math.cos(lon2)
+    var y = a * Math.cos(lat1) * Math.sin(lon1) + b * Math.cos(lat2) * Math.sin(lon2)
+    var z = a * Math.sin(lat1) + b * Math.sin(lat2)
+
+    var lat = Math.atan2(z, Math.sqrt(x * x + y * y))
+    var lon = Math.atan2(y, x)
+    return L.latLng(lat * 180 / Math.PI, lon * 180 / Math.PI)
+}
 
 $( document ).ready(function() {
 	mobileCheck()
@@ -61,6 +173,10 @@ $( document ).ready(function() {
     if (isIe()) {
         //remove all laser elements, as IE cannot handle it
         $(".laser").hide()
+    }
+
+    if (document.getElementById('map')) {
+        initMap()
     }
 
 })
@@ -130,7 +246,9 @@ function refreshMobileLayout() {
     } else {
         $("#reputationLevel").show()
 	}
-	delete(map)
+	if (map) {
+	    map.invalidateSize()
+	}
 	//yike, what if we miss something...the list below is kinda random
 	//initMap()
 	if (airports) {
@@ -301,32 +419,30 @@ function hideUserSpecificElements() {
 
 function initMap() {
 	initStyles()
-  map = new google.maps.Map(document.getElementById('map'), {
-	center: {lat: 20, lng: 150.644},
-   	zoom : 2,
-   	minZoom : 2,
-   	gestureHandling: 'greedy',
-   	styles: getMapStyles(),
-	mapTypeId: getMapTypes(),
-   	restriction: {
-                latLngBounds: { north: 85, south: -85, west: -180, east: 180 },
-              }
-  });
-	
-  google.maps.event.addListener(map, 'zoom_changed', function() {
-	    var zoom = map.getZoom();
-	    // iterate over markers and call setVisible
-	    $.each(markers, function( key, marker ) {
-	        marker.setVisible(isShowMarker(marker, zoom));
-	    })
-  });
-  
-  google.maps.event.addListener(map, 'maptypeid_changed', function() { 
-		var mapType = map.getMapTypeId();
-		$.cookie('currentMapTypes', mapType);
-  });
+    var bounds = L.latLngBounds(L.latLng(-85, -180), L.latLng(85, 180))
+    map = L.map(document.getElementById('map'), {
+        center: [20, 150.644],
+        zoom: 2,
+        minZoom: 2,
+        maxBounds: bounds,
+        worldCopyJump: true,
+        zoomControl: true
+    })
 
-  addCustomMapControls(map)
+    applyMapStyle(map)
+
+    map.on('zoomend', function() {
+        var zoom = map.getZoom()
+        // iterate over markers and call setVisible
+        $.each(markers, function(key, marker) {
+            setLeafletLayerVisibility(marker, isShowMarker(marker, zoom))
+            if (marker.contestedMarker) {
+                setLeafletLayerVisibility(marker.contestedMarker, map.hasLayer(marker))
+            }
+        })
+    })
+
+    addCustomMapControls(map)
 }
 
 function addCustomMapControls(map) {
@@ -352,26 +468,26 @@ function addCustomMapControls(map) {
 
 
   if ($("#map").height() > 500) {
-    map.controls[google.maps.ControlPosition.RIGHT_BOTTOM].push(toggleAllianceBaseMapViewButton[0]);
-    map.controls[google.maps.ControlPosition.RIGHT_BOTTOM].push(toggleMapLightButton[0]);
-    map.controls[google.maps.ControlPosition.RIGHT_BOTTOM].push(toggleMapAnimationButton[0]);
-    map.controls[google.maps.ControlPosition.RIGHT_BOTTOM].push(toggleChampionButton[0])
-    //map.controls[google.maps.ControlPosition.RIGHT_BOTTOM].push(toggleHeatmapButton[0])
+    addLeafletControlElement(map, "bottomright", toggleAllianceBaseMapViewButton[0])
+    addLeafletControlElement(map, "bottomright", toggleMapLightButton[0])
+    addLeafletControlElement(map, "bottomright", toggleMapAnimationButton[0])
+    addLeafletControlElement(map, "bottomright", toggleChampionButton[0])
+    //addLeafletControlElement(map, "bottomright", toggleHeatmapButton[0])
 
     if (christmasFlag) {
-       map.controls[google.maps.ControlPosition.RIGHT_BOTTOM].push(toggleMapChristmasButton[0]);
+       addLeafletControlElement(map, "bottomright", toggleMapChristmasButton[0])
        toggleMapChristmasButton.show()
     }
 
   } else {
-    map.controls[google.maps.ControlPosition.LEFT_BOTTOM].push(toggleAllianceBaseMapViewButton[0])
-    map.controls[google.maps.ControlPosition.LEFT_BOTTOM].push(toggleMapLightButton[0]);
-    map.controls[google.maps.ControlPosition.LEFT_BOTTOM].push(toggleMapAnimationButton[0]);
-    map.controls[google.maps.ControlPosition.LEFT_BOTTOM].push(toggleChampionButton[0])
-    //map.controls[google.maps.ControlPosition.LEFT_BOTTOM].push(toggleHeatmapButton[0])
+    addLeafletControlElement(map, "bottomleft", toggleAllianceBaseMapViewButton[0])
+    addLeafletControlElement(map, "bottomleft", toggleMapLightButton[0])
+    addLeafletControlElement(map, "bottomleft", toggleMapAnimationButton[0])
+    addLeafletControlElement(map, "bottomleft", toggleChampionButton[0])
+    //addLeafletControlElement(map, "bottomleft", toggleHeatmapButton[0])
 
     if (christmasFlag) {
-       map.controls[google.maps.ControlPosition.LEFT_BOTTOM].push(toggleMapChristmasButton[0]);
+       addLeafletControlElement(map, "bottomleft", toggleMapChristmasButton[0])
     }
   }
 }
@@ -382,9 +498,9 @@ function addAirlineSpecificMapControls(map) {
     toggleHeatmapButton.index = 4
 
     if ($("#map").height() > 500) {
-        map.controls[google.maps.ControlPosition.RIGHT_BOTTOM].insertAt(3, toggleHeatmapButton[0])
+        addLeafletControlElement(map, "bottomright", toggleHeatmapButton[0], 3)
      } else {
-        map.controls[google.maps.ControlPosition.LEFT_BOTTOM].insertAt(3, toggleHeatmapButton[0])
+        addLeafletControlElement(map, "bottomleft", toggleHeatmapButton[0], 3)
     }
 }
 

--- a/airline-web/public/javascripts/map-style.js
+++ b/airline-web/public/javascripts/map-style.js
@@ -1,427 +1,83 @@
 var currentStyles
 var currentTypes
 var pathOpacityByStyle = {
-    "dark" : {
-        highlight : "0.9",
-        normal : "0.5"
+    "dark": {
+        highlight: "0.9",
+        normal: "0.5"
     },
-    "light" : {
-        highlight : "1.0",
-        normal  : "0.8"
+    "light": {
+        highlight: "1.0",
+        normal: "0.8"
+    }
+}
+
+var mapStyleSources = {
+    dark: {
+        url: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
+        attribution: "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href=\"https://carto.com/attributions\">CARTO</a>"
+    },
+    light: {
+        url: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
+        attribution: "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href=\"https://carto.com/attributions\">CARTO</a>"
     }
 }
 
 function initStyles() {
-	console.log("onload cookie" + $.cookie('currentMapStyles'))
-	if ($.cookie('currentMapStyles')) {
-		currentStyles = $.cookie('currentMapStyles')
-	} else {
-		currentStyles = 'dark'
-		$.cookie('currentMapStyles', currentStyles);
-	}
-	console.log("onload " + currentStyles)
+    console.log("onload cookie" + $.cookie('currentMapStyles'))
+    if ($.cookie('currentMapStyles')) {
+        currentStyles = $.cookie('currentMapStyles')
+    } else {
+        currentStyles = 'dark'
+        $.cookie('currentMapStyles', currentStyles)
+    }
+    console.log("onload " + currentStyles)
 
-	console.log("onload cookie" + $.cookie('currentMapTypes'))
-	if ($.cookie('currentMapTypes')) {
-		currentTypes = $.cookie('currentMapTypes')
-	} else {
-		currentTypes = 'roadmap'
-		$.cookie('currentMapTypes', currentTypes);
-	}
-	console.log("onload " + currentTypes)
+    console.log("onload cookie" + $.cookie('currentMapTypes'))
+    if ($.cookie('currentMapTypes')) {
+        currentTypes = $.cookie('currentMapTypes')
+    } else {
+        currentTypes = 'roadmap'
+        $.cookie('currentMapTypes', currentTypes)
+    }
+    console.log("onload " + currentTypes)
 }
 
 function getMapStyles() {
-	console.log("getting " + currentStyles)
-	if (currentStyles == 'light') {
-		return lightStyles
-	} else {
-		return darkStyles
-	}
+    console.log("getting " + currentStyles)
+    return currentStyles
 }
 
 function getMapTypes() {
-	console.log("getting " + currentTypes)
-	return currentTypes
+    console.log("getting " + currentTypes)
+    return currentTypes
+}
+
+function applyMapStyle(mapInstance) {
+    if (!mapInstance) {
+        return
+    }
+    var style = getMapStyles()
+    var source = mapStyleSources[style] || mapStyleSources.dark
+    if (mapInstance._styleLayer) {
+        mapInstance.removeLayer(mapInstance._styleLayer)
+    }
+    var layer = L.tileLayer(source.url, {
+        attribution: source.attribution,
+        maxZoom: 19
+    })
+    layer.addTo(mapInstance)
+    mapInstance._styleLayer = layer
 }
 
 function toggleMapLight() {
-	if (currentStyles == 'dark') {
-		currentStyles = 'light'
-	} else {
-		currentStyles = 'dark'
-	}
-	$.cookie('currentMapStyles', currentStyles);
-	console.log($.cookie('currentMapStyles'))
-	
-	map.setOptions({styles: getMapStyles()});
-	refreshLinks(false)
-}
+    if (currentStyles == 'dark') {
+        currentStyles = 'light'
+    } else {
+        currentStyles = 'dark'
+    }
+    $.cookie('currentMapStyles', currentStyles)
+    console.log($.cookie('currentMapStyles'))
 
-var darkStyles =  
-   	[
-   	  {
-   	    "elementType": "geometry",
-   	    "stylers": [
-   	      {
-   	        "color": "#1d2c4d"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "elementType": "labels.text.fill",
-   	    "stylers": [
-   	      {
-   	        "color": "#8ec3b9"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "elementType": "labels.text.stroke",
-   	    "stylers": [
-   	      {
-   	        "color": "#1a3646"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "administrative.country",
-   	    "elementType": "geometry.stroke",
-   	    "stylers": [
-   	      {
-   	        "color": "#4b6878"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "administrative.land_parcel",
-   	    "elementType": "labels",
-   	    "stylers": [
-   	      {
-   	        "visibility": "off"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "administrative.land_parcel",
-   	    "elementType": "labels.text.fill",
-   	    "stylers": [
-   	      {
-   	        "color": "#64779e"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "administrative.province",
-   	    "elementType": "geometry.stroke",
-   	    "stylers": [
-   	      {
-   	    	"visibility": "off"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "landscape.man_made",
-   	    "elementType": "geometry.stroke",
-   	    "stylers": [
-   	      {
-   	        "color": "#334e87"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "landscape.natural",
-   	    "elementType": "geometry",
-   	    "stylers": [
-   	      {
-   	        "color": "#023e58"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "poi",
-   	    "elementType": "geometry",
-   	    "stylers": [
-   	      {
-   	        "color": "#283d6a"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "poi",
-   	    "elementType": "labels.text",
-   	    "stylers": [
-   	      {
-   	        "visibility": "off"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "poi",
-   	    "elementType": "labels.text.fill",
-   	    "stylers": [
-   	      {
-   	        "color": "#6f9ba5"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "poi",
-   	    "elementType": "labels.text.stroke",
-   	    "stylers": [
-   	      {
-   	        "color": "#1d2c4d"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "poi.business",
-   	    "stylers": [
-   	      {
-   	        "visibility": "off"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "poi.park",
-   	    "elementType": "geometry.fill",
-   	    "stylers": [
-   	      {
-   	        "color": "#023e58"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "poi.park",
-   	    "elementType": "labels.text.fill",
-   	    "stylers": [
-   	      {
-   	        "color": "#3C7680"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "road",
-   	    "stylers": [
-   	      {
-   	        "visibility": "off"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "road",
-   	    "elementType": "geometry",
-   	    "stylers": [
-   	      {
-   	        "color": "#304a7d"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "road",
-   	    "elementType": "labels.icon",
-   	    "stylers": [
-   	      {
-   	        "visibility": "off"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "road",
-   	    "elementType": "labels.text.fill",
-   	    "stylers": [
-   	      {
-   	        "color": "#98a5be"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "road",
-   	    "elementType": "labels.text.stroke",
-   	    "stylers": [
-   	      {
-   	        "color": "#1d2c4d"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "road.highway",
-   	    "elementType": "geometry",
-   	    "stylers": [
-   	      {
-   	        "color": "#2c6675"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "road.highway",
-   	    "elementType": "geometry.stroke",
-   	    "stylers": [
-   	      {
-   	        "color": "#255763"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "road.highway",
-   	    "elementType": "labels.text.fill",
-   	    "stylers": [
-   	      {
-   	        "color": "#b0d5ce"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "road.highway",
-   	    "elementType": "labels.text.stroke",
-   	    "stylers": [
-   	      {
-   	        "color": "#023e58"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "road.local",
-   	    "elementType": "labels",
-   	    "stylers": [
-   	      {
-   	        "visibility": "off"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "transit",
-   	    "stylers": [
-   	      {
-   	        "visibility": "off"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "transit",
-   	    "elementType": "labels.text.fill",
-   	    "stylers": [
-   	      {
-   	        "color": "#98a5be"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "transit",
-   	    "elementType": "labels.text.stroke",
-   	    "stylers": [
-   	      {
-   	        "color": "#1d2c4d"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "transit.line",
-   	    "elementType": "geometry.fill",
-   	    "stylers": [
-   	      {
-   	        "color": "#283d6a"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "transit.station",
-   	    "elementType": "geometry",
-   	    "stylers": [
-   	      {
-   	        "color": "#3a4762"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "water",
-   	    "elementType": "geometry",
-   	    "stylers": [
-   	      {
-   	        "color": "#0e1626"
-   	      }
-   	    ]
-   	  },
-   	  {
-   	    "featureType": "water",
-   	    "elementType": "labels.text.fill",
-   	    "stylers": [
-   	      {
-   	        "color": "#4e6d70"
-   	      }
-   	    ]
-   	  }
-   	]
-var lightStyles = 
-	[
-	    {
-	        "featureType": "road",
-	        "stylers": [
-	            {
-	                "visibility": "off"
-	            }
-	        ]
-	    },
-	    {
-	        "featureType": "transit",
-	        "stylers": [
-	            {
-	                "visibility": "off"
-	            }
-	        ]
-	    },
-	    {
-	        "featureType": "administrative.province",
-	        "stylers": [
-	            {
-	                "visibility": "off"
-	            }
-	        ]
-	    },
-	    {
-	        "featureType": "poi.park",
-	        "elementType": "geometry",
-	        "stylers": [
-	            {
-	                "visibility": "off"
-	            }
-	        ]
-	    },
-	    {
-	        "featureType": "water",
-	        "stylers": [
-	            {
-	                "color": "#004b76"
-	            }
-	        ]
-	    },
-	    {
-	        "featureType": "landscape.natural",
-	        "stylers": [
-	            {
-	                "visibility": "on"
-	            },
-	            {
-	                "color": "#fff6cb"
-	            }
-	        ]
-	    },
-	    {
-	        "featureType": "administrative.country",
-	        "elementType": "geometry.stroke",
-	        "stylers": [
-	            {
-	                "visibility": "on"
-	            },
-	            {
-	                "color": "#7f7d7a"
-	            },
-	            {
-	                "lightness": 10
-	            },
-	            {
-	                "weight": 1
-	            }
-	        ]
-	    }
-	]
+    applyMapStyle(map)
+    refreshLinks(false)
+}

--- a/airline-web/public/javascripts/rivals.js
+++ b/airline-web/public/javascripts/rivals.js
@@ -421,9 +421,10 @@ function showRivalMap() {
                     var path = drawFlightPath(link, "#DC83FC")
                     paths.push(path)
                     //remove on click add on hover
-                    google.maps.event.clearInstanceListeners(path.shadow);
-                    var infoWindow
-                    path.shadow.addListener('mouseover', function(event) {
+                    path.shadow.off('mouseover')
+                    path.shadow.off('mouseout')
+                    var infoPopup = L.popup({ maxWidth: 1200, autoPan: false, closeButton: false })
+                    path.shadow.on('mouseover', function(event) {
                         var fromAirport = getAirportText(link.fromAirportCity, link.fromAirportCode)
                     	var toAirport = getAirportText(link.toAirportCity, link.toAirportCode)
                         $("#linkPopupFrom").html(getCountryFlagImg(link.fromCountryCode) + "&nbsp;" + fromAirport)
@@ -431,19 +432,14 @@ function showRivalMap() {
                         $("#linkPopupCapacity").html(link.capacity.total)
                         $("#linkPopupAirline").html(getAirlineSpan(link.airlineId, link.airlineName))
 
-                        infoWindow = new google.maps.InfoWindow({
-                             maxWidth : 1200});
-
                         var popup = $("#linkPopup").clone()
                         popup.show()
-                        infoWindow.setContent(popup[0])
-
-                        infoWindow.setPosition(event.latLng);
-                        infoWindow.open(map);
+                        infoPopup.setContent(popup[0])
+                        infoPopup.setLatLng(event.latlng)
+                        infoPopup.openOn(map)
                     })
-                    path.shadow.addListener('mouseout', function(event) {
-                        infoWindow.close();
-                        infoWindow.setMap(null);
+                    path.shadow.on('mouseout', function(event) {
+                        map.closePopup(infoPopup)
                     })
                 })
 
@@ -476,14 +472,15 @@ function showRivalMap() {
     	    }
     });
     window.setTimeout(function() {
-        if (map.controls[google.maps.ControlPosition.TOP_CENTER].getLength() > 0) {
-            map.controls[google.maps.ControlPosition.TOP_CENTER].clear()
+        var container = getLeafletControlContainer(map, "topcenter")
+        if (container && container.childElementCount > 0) {
+            clearLeafletControlContainer(map, "topcenter")
         }
-        map.controls[google.maps.ControlPosition.TOP_CENTER].push(createMapButton(map, 'Exit Rival Flight Map', 'hideRivalMap()', 'hideRivalMapButton')[0]);
+        addLeafletControlElement(map, "topcenter", createMapButton(map, 'Exit Rival Flight Map', 'hideRivalMap()', 'hideRivalMapButton')[0])
     }, 1000); //delay otherwise it doesn't push to center
     switchMap()
     $("#worldMapCanvas").data("initCallback", function() { //if go back to world map, re-init the map
-    	map.controls[google.maps.ControlPosition.TOP_CENTER].clear()
+    	clearLeafletControlContainer(map, "topcenter")
     	clearAllPaths()
         updateAirportMarkers(activeAirline)
         updateLinksInfo() //redraw all flight paths
@@ -491,7 +488,7 @@ function showRivalMap() {
 }
 
 function hideRivalMap() {
-	map.controls[google.maps.ControlPosition.TOP_CENTER].clear()
+	clearLeafletControlContainer(map, "topcenter")
 	clearAllPaths()
 	updateAirportBaseMarkers([]) //revert base markers
 	rivalMapAirlineId = undefined

--- a/airline-web/public/javascripts/test-airport.js
+++ b/airline-web/public/javascripts/test-airport.js
@@ -6,13 +6,20 @@ $( document ).ready(function() {
 	flightPaths = []
 	activeInput = $("#fromAirport")
 	loadAirlines()
+    if (document.getElementById('map')) {
+        initMap()
+    }
 })
 
 function initMap() {
-  map = new google.maps.Map(document.getElementById('map'), {
-	center: {lat: 20, lng: 150.644},
-   	zoom : 2
-  });
+  map = L.map(document.getElementById('map'), {
+      center: [20, 150.644],
+      zoom: 2
+  })
+  L.tileLayer("https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png", {
+      attribution: "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href=\"https://carto.com/attributions\">CARTO</a>",
+      maxZoom: 19
+  }).addTo(map)
   
   getAirports()
   refreshLinks()
@@ -21,16 +28,15 @@ function initMap() {
 function addMarkers(airports) {
 	for (i = 0; i < airports.length; i++) {
 		  var airportInfo = airports[i]
-		  var position = {lat: airportInfo.latitude, lng: airportInfo.longitude};
-		  var marker = new google.maps.Marker({
-			    position: position,
-			    map: map,
-			    title: airportInfo.name,
-		  		airportCode: airportInfo.iata,
-		  		airportId: airportInfo.id
-			  });
+		  var marker = L.marker([airportInfo.latitude, airportInfo.longitude], {
+			    title: airportInfo.name
+			  })
+          marker.__mapRef = map
+          marker.airportCode = airportInfo.iata
+          marker.airportId = airportInfo.id
+          marker.addTo(map)
 		  
-		  marker.addListener('click', function() {
+		  marker.on('click', function() {
 			  var airportId = this.airportId
 			  if (activeInput.is($("#fromAirport"))) {
 				  $("#fromAirport").val(airportId)
@@ -126,7 +132,7 @@ function removeAllLinks() {
 function refreshLinks() {
 	//remove all links from UI first
 	$.each(flightPaths, function( key, value ) {
-		  value.setMap(null)
+		  map.removeLayer(value)
 		});
 	flightPaths = []
 	
@@ -148,15 +154,13 @@ function refreshLinks() {
 }
 
 function drawFlightPath(link) {
-   var flightPath = new google.maps.Polyline({
-     path: [{lat: link.fromLatitude, lng: link.fromLongitude}, {lat: link.toLatitude, lng: link.toLongitude}], 
-     geodesic: true,
-     strokeColor: '#F2B022',
-     strokeOpacity: 1.0,
-     strokeWeight: 2
-                           });
-   
-   flightPath.setMap(map)
+   var flightPath = L.polyline([[link.fromLatitude, link.fromLongitude], [link.toLatitude, link.toLongitude]], {
+       color: '#F2B022',
+       opacity: 1.0,
+       weight: 2
+   })
+   flightPath.__mapRef = map
+   flightPath.addTo(map)
    flightPaths.push(flightPath)
 }
 


### PR DESCRIPTION
### Motivation
- Replace direct Google Maps usage with an open Leaflet/MapLibre-style stack to remove the Google Maps dependency and use tile-based styling and simpler client-side overlays. 
- Provide a unified Leaflet API for markers, polylines, circles, popups and events so map features (flight paths, airports, campaigns, alliances, heatmaps, history) can be managed consistently.
- Implement a portable great-circle interpolation helper for flight animations previously relying on Google geometry utilities.

### Description
- Replaced Google Maps map creation, markers, polylines, circles, info windows and event listeners with Leaflet equivalents across major map-driven modules and views, and added Leaflet CSS/JS to templates (`index.scala.html`, `test.scala.html`). Files updated include `main.js`, `airport.js`, `airline.js`, `alliance.js`, `campaign.js`, `event.js`, `heatmap.js`, `link-history.js`, `rivals.js`, `christmas.js`, `test-airport.js`, and `map-style.js` (new).
- Added Leaflet helper utilities in `main.js`: `createLeafletIcon`, `setLeafletLayerVisibility`, `getLeafletControlContainer`, `clearLeafletControlContainer`, `addLeafletControlElement`, and `interpolateGreatCircle`; these central helpers are used for icons, layer visibility, custom control containers and great-circle interpolation for marker animation.
- Implemented `applyMapStyle` and a lightweight tile-source configuration in `map-style.js` to switch between light/dark tile layers rather than Google map style objects; updated `toggleMapLight()` to switch tile layers.
- Converted popups to Leaflet `bindPopup`/`L.popup` usages and converted Google map control placements to DOM-based Leaflet control containers via `addLeafletControlElement`/`getLeafletControlContainer`.
- Reworked flight/route drawing and animations to use `L.polyline`, `L.marker`, and the custom great-circle interpolator; heatmap rendering was reimplemented as a simple tiled/circle-based layer builder (in `heatmap.js`) using `buildHeatmapLayer`.
- Reworked all relevant event handlers from Google Maps listeners to Leaflet `on`, `off`, `once` where applicable and updated many helper callers to the new API (examples: `drawFlightPath`, `drawAirportLinkPath`, `drawAllianceLink`, `drawHistoryFlightMarker`, `addMarkers`, `addCityMarkers`, `populateCampaignMap`).

### Testing
- No automated tests were run for this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976a0938b108332b1d72d0a82e809a1)