### PR TITLE
Deprecate google.mapKey; add `map.provider` OSM config and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Live at https://myfly.club/
 1. Navigate to `airline-data` and run `sbt publishLocal`. If you see [encoding error](https://github.com/patsonluk/airline/issues/267), add character-set-server=utf8mb4 to your /etc/my.cnf and restart mysql. it's a unicode characters issue, see https://stackoverflow.com/questions/10957238/incorrect-string-value-when-trying-to-insert-utf-8-into-mysql-via-jdbc
 1. In `airline-data`, run `sbt run`, 
     1. Then, choose the one that runs `MainInit`. It will take awhile to init everything.
-1. Set `google.mapKey` in [`application.conf`](https://github.com/patsonluk/airline/blob/master/airline-web/conf/application.conf#L69) with your google map API key value. Be careful with setting budget and limit, google gives some free credit but it CAN go over and you might get charged!
+1. Configure the OpenStreetMap tile provider in `airline-web/conf/application.conf` under `map.provider` (base tile URL and attribution). The default uses OpenStreetMap tiles and does not require an API key.
 1. For the "Flight search" function to work, install elastic search 7.x, see https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html . For windows, I recommand downloading the zip archive and just unzip it - the MSI installer did not work on my PC
 1. For airport image search and email service for user pw reset - refer to https://github.com/patsonluk/airline/blob/master/airline-web/README
 1. Now run the background simulation by staying in `airline-data`, run `sbt run`, select option `MainSimulation`. It should run the background simulation.

--- a/airline-web/README
+++ b/airline-web/README
@@ -4,7 +4,7 @@ Then copy the credentials json and put it to `conf` folder with name `gmail-cred
 
 The banner fetcher uses Wikimedia Commons search. You can override the default search term with `wikimedia.bannerSearch` in `application.conf`.
 
-For google map usage, set `google.mapKey` in `application.conf`
+Maps use OpenStreetMap tiles by default. Adjust `map.provider.baseTileUrl` and `map.provider.attribution` in `application.conf` if you need a different tile service (some providers may require their own API keys).
 
 Cities datasource
 http://download.geonames.org/export/dump/cities500.zip

--- a/airline-web/conf/application.conf
+++ b/airline-web/conf/application.conf
@@ -81,7 +81,12 @@ my-pinned-dispatcher {
 
 sim.pekko-actor.host="127.0.0.1:2552"
 google.apiKey="AIzaSyCDFSpl_SVQWtPd_FKZ627Cb2gN0d4izsc"
-google.mapKey="AIzaSyChKaQ_xLFAdrhuY4EVE6ahggn9Jteq5qY"
+
+# Map provider configuration (OpenStreetMap by default).
+map.provider {
+  baseTileUrl = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+  attribution = "&copy; OpenStreetMap contributors"
+}
 
 play.allowGlobalApplication = true
 


### PR DESCRIPTION
### Motivation
- Remove the deprecated `google.mapKey` configuration and move to a provider-agnostic map configuration to avoid relying on a Google API key.
- Make the application default to OpenStreetMap tiles and document how to change tile provider and attribution.

### Description
- Removed `google.mapKey` from `airline-web/conf/application.conf` and added a `map.provider` block containing `baseTileUrl` and `attribution` (defaults to OSM tiles).
- Updated top-level `README.md` to instruct users to configure `map.provider` in `airline-web/conf/application.conf` and note that OSM does not require an API key by default.
- Updated `airline-web/README` to document that maps use OpenStreetMap tiles by default and to explain how to change `map.provider.baseTileUrl` and `map.provider.attribution` if using another tile service.
- Left Google-related code paths untouched where present, but removed the injected `google.mapKey` config value so templates no longer receive that key from `application.conf`.

### Testing
- Automated tests: none were run because this change only updates configuration and documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976e036cef88332a6981815690096c3)