### PR TITLE
fix: switch map tiles to Protomaps API (fixes CORS in dev/CI)

### DIFF
--- a/airline-web/public/javascripts/map/styles.js
+++ b/airline-web/public/javascripts/map/styles.js
@@ -164,7 +164,7 @@ function createTheme(name) {
             protomaps: {
                 type: 'vector',
                 tiles: [
-                    'https://maps.myfly.club/mfc/{z}/{x}/{y}.mvt'
+                    'https://api.protomaps.com/tiles/v4/{z}/{x}/{y}.mvt?key=628d1d8c9eb71ab8'
                 ],
                 maxzoom: 11,
                 attribution: '<a href="https://protomaps.com">Protomaps</a> © <a href="https://openstreetmap.org">OpenStreetMap</a>'


### PR DESCRIPTION
## Problem
`maps.myfly.club` (the upstream forked tile server) does not return `Access-Control-Allow-Origin` headers. This causes the browser to block tile requests when accessing the app from any origin other than the production domain, breaking the world map in dev and CI environments.

## Fix
Switch to the [Protomaps API](https://protomaps.com) free tier, which:
- Uses the same OSM-derived vector tile data
- Uses the identical layer schema (`earth`, `water`, `landuse`, `boundaries`, etc.) — zero style changes needed
- Returns proper CORS headers for all origins
- Free tier: 200k tiles/month

## Change
One line in `styles.js` — tile URL only.