### PR TITLE
feat(ci): Add Playwright e2e scaffold and CI build workflow (ported from #10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: sbt
+
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: Install e2e dependencies
+        run: npm ci --prefix e2e
+
+      # Full `sbt test` needs a live MySQL instance, so CI stops at
+      # compile-level verification plus Playwright suite discovery.
+      - name: Compile airline-data and publish locally
+        run: cd airline-data && sbt compile publishLocal
+
+      - name: Compile airline-web
+        run: cd airline-web && sbt compile
+
+      - name: Verify Playwright suite discovery
+        run: npm --prefix e2e run test:list

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /airline-data/.bsp
 *.sql
 node_modules
+e2e/test-results/
+e2e/playwright-report/

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.58.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test",
+    "test:list": "playwright test --list"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.58.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 60_000,
+  retries: 1, // enables trace-on-retry usefulness
+  use: {
+    baseURL: "http://localhost:9000",
+    headless: true,
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+    video: "retain-on-failure",
+  },
+  reporter: [["html", { open: "never" }], ["list"]],
+  outputDir: "test-results",
+});

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@playwright/test";
+
+test("homepage loads", async ({ page }, testInfo) => {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  // Loosen this assertion initially; we can tighten once we know the UI.
+  await expect(page).toHaveTitle(/airline/i);
+
+  // Optional: always capture a baseline screenshot for quick review
+  await page.screenshot({ path: testInfo.outputPath("homepage.png"), fullPage: true });
+});


### PR DESCRIPTION
## Summary
Ports the still-applicable pieces of #10 (low-resource-local-mode) onto the v5 codebase:
- `e2e/` Playwright setup with a homepage smoke test (baseURL `http://localhost:9000`, screenshots/traces on failure)
- `.github/workflows/ci.yml` that compiles `airline-data` (+ `publishLocal`), compiles `airline-web`, and verifies Playwright suite discovery

The rest of #10 is obsolete on v5: search is already in-process with no Elasticsearch dependency, the bounded simulation thread pool landed via #13, and Hikari pool tuning via #14.

## Validation
- `npm --prefix e2e ci && npm --prefix e2e run test:list` — discovers the smoke test
- `sbt compile publishLocal` (airline-data) and `sbt compile` (airline-web) both pass locally on this branch

## Notes
Full `sbt test` requires a live MySQL instance (same blocker documented in #10), so CI intentionally stops at compile-level verification + test discovery.

https://claude.ai/code/session_01SWKFjtc6iiSApwuJQyPNYU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWKFjtc6iiSApwuJQyPNYU)_