### PR TITLE
feat(simulation): Pause simulation cycles when no player is active

### DIFF
--- a/airline-data/src/main/resources/application.conf
+++ b/airline-data/src/main/resources/application.conf
@@ -36,3 +36,11 @@ hikari.connectionTimeout = 90000
 # Bounded thread pool backing the simulation actor system.
 # Defaults to max(4, number of CPU cores) when unset.
 # simulation.threadPoolSize = 4
+
+# Pause-when-idle (single-player): skip simulation cycles while no player has
+# been active. The web app records activity (login + connected websocket
+# sessions) in the activity_heartbeat table; deploy web and sim from the same
+# version when enabling. Game time stops while paused; no catch-up on return.
+# simulation.pauseWhenIdle = true
+# simulation.idleGraceMinutes = 60
+# simulation.idleRecheckMinutes = 5

--- a/airline-data/src/main/scala/com/patson/MainSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/MainSimulation.scala
@@ -18,6 +18,24 @@ object MainSimulation extends App {
   val SCHEDULE_OVERHEAD_FACTOR : Double = 1.1
   var currentWeek: Int = 0
 
+  //pause-when-idle: skip cycles while no player has been active (heartbeat written by the web app)
+  val pauseWhenIdle : Boolean = Constants.configFactory.hasPath("simulation.pauseWhenIdle") && Constants.configFactory.getBoolean("simulation.pauseWhenIdle")
+  val idleGraceMinutes : Long = if (Constants.configFactory.hasPath("simulation.idleGraceMinutes")) Constants.configFactory.getLong("simulation.idleGraceMinutes") else 60
+  val idleRecheckMinutes : Long = if (Constants.configFactory.hasPath("simulation.idleRecheckMinutes")) Constants.configFactory.getLong("simulation.idleRecheckMinutes") else 5
+
+  def isIdle() : Boolean = {
+    try {
+      HeartbeatSource.lastActiveMillis() match {
+        case Some(lastActive) => System.currentTimeMillis() - lastActive > idleGraceMinutes * 60000L
+        case None => true //no player has ever been active on this install
+      }
+    } catch {
+      case e : Exception =>
+        println(s"Failed to read activity heartbeat (${e.getMessage}), running the cycle anyway")
+        false
+    }
+  }
+
   mainFlow
 
   def mainFlow() = {
@@ -149,6 +167,11 @@ object MainSimulation extends App {
 
         println(s"Next cycle will wake up in ${delayUntilWakeUp / 1000}s (estimated exec: ${estimatedExecution / 1000}s)")
         context.system.scheduler.scheduleOnce(Duration(delayUntilWakeUp, TimeUnit.MILLISECONDS), self, ExecuteProcessing)
+
+      case ExecuteProcessing if pauseWhenIdle && isIdle() =>
+        status = SimulationStatus.WAITING_CYCLE_START
+        println(s"Simulation paused: no player activity within the last $idleGraceMinutes min. Rechecking in $idleRecheckMinutes min")
+        context.system.scheduler.scheduleOnce(Duration(idleRecheckMinutes, TimeUnit.MINUTES), self, ExecuteProcessing)
 
       case ExecuteProcessing =>
         status = SimulationStatus.IN_PROGRESS

--- a/airline-data/src/main/scala/com/patson/data/HeartbeatSource.scala
+++ b/airline-data/src/main/scala/com/patson/data/HeartbeatSource.scala
@@ -1,0 +1,46 @@
+package com.patson.data
+
+import java.sql.Connection
+import scala.util.Using
+
+/**
+  * Records the last time any player was active. Written by the web app
+  * (login + periodic touch while websocket sessions are connected) and read by
+  * the simulation's pause-when-idle check (see MainSimulation).
+  *
+  * The table is created lazily so no migration is required on existing databases.
+  */
+object HeartbeatSource {
+  val ACTIVITY_HEARTBEAT_TABLE = "activity_heartbeat"
+
+  @volatile private var tableEnsured = false
+
+  private def ensureTable(connection : Connection) : Unit = {
+    if (!tableEnsured) {
+      Using.resource(connection.prepareStatement("CREATE TABLE IF NOT EXISTS " + ACTIVITY_HEARTBEAT_TABLE + "(id INTEGER PRIMARY KEY, last_active TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)")) { statement =>
+        statement.execute()
+      }
+      tableEnsured = true
+    }
+  }
+
+  def touch() : Unit = {
+    Using.resource(Meta.getConnection()) { connection =>
+      ensureTable(connection)
+      Using.resource(connection.prepareStatement("INSERT INTO " + ACTIVITY_HEARTBEAT_TABLE + "(id, last_active) VALUES(1, CURRENT_TIMESTAMP) ON DUPLICATE KEY UPDATE last_active = CURRENT_TIMESTAMP")) { statement =>
+        statement.executeUpdate()
+      }
+    }
+  }
+
+  def lastActiveMillis() : Option[Long] = {
+    Using.resource(Meta.getConnection()) { connection =>
+      ensureTable(connection)
+      Using.resource(connection.prepareStatement("SELECT last_active FROM " + ACTIVITY_HEARTBEAT_TABLE + " WHERE id = 1")) { statement =>
+        Using.resource(statement.executeQuery()) { resultSet =>
+          if (resultSet.next()) Some(resultSet.getTimestamp("last_active").getTime) else None
+        }
+      }
+    }
+  }
+}

--- a/airline-web/app/controllers/UserApplication.scala
+++ b/airline-web/app/controllers/UserApplication.scala
@@ -7,7 +7,7 @@ import play.api.mvc._
 import play.api.libs.json.Writes
 import com.patson.model.{Airline, User, UserStatus}
 import play.api.libs.json._
-import com.patson.data.{AllianceSource, IpSource, UserSource, UserUuidSource}
+import com.patson.data.{AllianceSource, HeartbeatSource, IpSource, UserSource, UserUuidSource}
 import com.patson.util.AllianceCache
 
 import java.util.UUID
@@ -74,6 +74,11 @@ class UserApplication @Inject()(cc: ControllerComponents) extends AbstractContro
       IpSource.saveUserIp(request.user.id, request.remoteAddress)
 
       UserSource.updateUserLastActive(request.user)
+      try {
+        HeartbeatSource.touch() //wake the simulation if it is paused-when-idle
+      } catch {
+        case e : Exception => println(s"Failed to write activity heartbeat: ${e.getMessage}")
+      }
       if (request.user.status == UserStatus.INACTIVE) {
         UserSource.updateUser(request.user.copy(status = UserStatus.ACTIVE))
       }

--- a/airline-web/app/websocket/ActorCenter.scala
+++ b/airline-web/app/websocket/ActorCenter.scala
@@ -3,6 +3,7 @@ package websocket
 import org.apache.pekko.actor.{Actor, ActorRef, ActorSelection, ActorSystem, Cancellable, Props, Terminated}
 import org.apache.pekko.pattern.after
 import org.apache.pekko.remote.{AssociatedEvent, DisassociatedEvent, RemotingLifecycleEvent}
+import com.patson.data.HeartbeatSource
 import com.patson.model.{Airline, NotificationCategory}
 import com.patson.stream.{CycleCompleted, CycleInfo, KeepAlivePing, KeepAlivePong, ReconnectPing, SimulationEvent}
 import com.patson.util.{AirlineCache, AirplaneOwnershipCache, AirportCache, AirportStatisticsCache}
@@ -250,6 +251,18 @@ object ActorCenter {
   val remoteMainActor = remoteSystem.actorSelection("pekko://" + REMOTE_SYSTEM_NAME + "@" + actorHost + "/user/" + BRIDGE_ACTOR_NAME)
   val localMainActor = remoteSystem.actorOf(Props(classOf[LocalMainActor], remoteMainActor), "local-main-actor")
   val reconnectActor = remoteSystem.actorOf(Props(classOf[ReconnectActor], remoteMainActor), "reconnect-actor")
+
+  //record player activity while sessions are connected, so the simulation's
+  //pause-when-idle check (simulation.pauseWhenIdle) sees the server as active
+  remoteSystem.scheduler.scheduleWithFixedDelay(1.minute, 1.minute)(() =>
+    if (chat.ChatControllerActor.getActiveUsers().nonEmpty) {
+      try {
+        HeartbeatSource.touch()
+      } catch {
+        case e : Exception => println(s"Failed to write activity heartbeat: ${e.getMessage}")
+      }
+    }
+  )(remoteSystem.dispatcher)
 
   def getLocalSubscriberName(subscriberId: String): String = {
     "local-subscriber-" + subscriberId


### PR DESCRIPTION
PR 2 of 4 from `docs/single-player-performance-roadmap.md`: stop burning a full world simulation every 29 minutes when nobody is playing.

## How it works
- New opt-in config in airline-data (defaults preserve upstream behavior):
  - `simulation.pauseWhenIdle = false`
  - `simulation.idleGraceMinutes = 60`
  - `simulation.idleRecheckMinutes = 5`
- `MainSimulationActor` checks the activity heartbeat before each `ExecuteProcessing`: if idle past the grace window, it skips the cycle and reschedules a cheap recheck. The cycle counter only advances when a cycle actually runs, so game time stops while away — no catch-up burst on return.
- New `HeartbeatSource` (airline-data) with a lazily-created `activity_heartbeat` table (`CREATE TABLE IF NOT EXISTS` — no migration needed). Fails open: heartbeat read errors never block the simulation.
- The web app writes the heartbeat on login (`UserApplication.login`) and once a minute while websocket sessions are connected (`ActorCenter` scheduler + `ChatControllerActor.getActiveUsers()`).

## Known limitation
While paused, the web UI cycle countdown (driven by `CycleInfo`) shows a stale estimate — documented in the roadmap as optional later polish.

## Validation
- Both modules compile (`airline-data` `publishLocal` + `airline-web compile`)
- On-box: enable the flag, leave no sessions → logs show `Simulation paused: no player activity…` and near-zero CPU; logging in resumes within one recheck interval

https://claude.ai/code/session_01SWKFjtc6iiSApwuJQyPNYU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWKFjtc6iiSApwuJQyPNYU)_