### PR TITLE
chore(ci): Run production deploy manually only

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,9 +1,10 @@
 name: Production Deploy
 run-name: ${{ github.actor }} prod deploy 🚀
+# The deploy target server no longer exists in this fork's environment;
+# keep the workflow available for manual runs only instead of failing
+# on every master push.
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
The `Production Deploy` workflow targets a server that no longer exists in this fork's environment, so it failed on every master push (every merge today produced a red ❌). Switch it to `workflow_dispatch` so it only runs when triggered manually. `sandbox-deploy.yml` is untouched — it only fires on a `sandbox` branch that doesn't exist.

https://claude.ai/code/session_01SWKFjtc6iiSApwuJQyPNYU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWKFjtc6iiSApwuJQyPNYU)_