### PR TITLE
feat(simulation): Log per-phase timings for each simulation cycle

### DIFF
--- a/airline-data/src/main/scala/com/patson/MainSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/MainSimulation.scala
@@ -8,6 +8,7 @@ import com.patson.stream.{CycleCompleted, CycleStart, SimulationEventStream}
 import com.patson.model.CountryAirlineTitle
 import com.patson.util.{AirlineCache, AirplaneOwnershipCache, AirportCache, AirportStatisticsCache}
 
+import scala.collection.mutable.ListBuffer
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
@@ -62,55 +63,85 @@ object MainSimulation extends App {
   def startCycle(cycle : Int) = {
     val cycleStartTime = System.currentTimeMillis()
     println("cycle " + cycle + " starting!")
+
+    val phaseTimings = ListBuffer[(String, Long)]()
+    def timed[T](phaseName : String)(block : => T) : T = {
+      val phaseStart = System.currentTimeMillis()
+      val result = block
+      phaseTimings += ((phaseName, System.currentTimeMillis() - phaseStart))
+      result
+    }
+
     if (cycle == 1) { //initialize it
       OilSimulation.simulate(1)
       LoanInterestRateSimulation.simulate(1)
     }
 
     SimulationEventStream.publish(CycleStart(cycle, cycleStartTime), None)
-    invalidateCaches()
-    initializeCaches()
+    timed("caches") {
+      invalidateCaches()
+      initializeCaches()
+    }
 
-    UserSimulation.simulate(cycle)
+    timed("user") {
+      UserSimulation.simulate(cycle)
+    }
     println("Event simulation")
-    EventSimulation.simulate(cycle)
+    timed("event") {
+      EventSimulation.simulate(cycle)
+    }
     println("Event simulation done")
 
     println("Link simulation starting")
-    val (flightLinkResult, loungeResult, linkRidershipDetails, paxStatsByAirlineId) = LinkSimulation.linkSimulation(cycle)
+    val (flightLinkResult, loungeResult, linkRidershipDetails, paxStatsByAirlineId) = timed("link") {
+      LinkSimulation.linkSimulation(cycle)
+    }
     println("Link simulation done")
 
     println("Airport simulation")
-    val airportChampionInfo = AirportSimulation.airportSimulation(cycle, linkRidershipDetails)
+    val airportChampionInfo = timed("airport") {
+      AirportSimulation.airportSimulation(cycle, linkRidershipDetails)
+    }
     println("Airport simulation done")
 
     println("Alliance simulation")
-    AllianceSimulation.simulate(flightLinkResult, loungeResult, paxStatsByAirlineId, airportChampionInfo, cycle)
+    timed("alliance") {
+      AllianceSimulation.simulate(flightLinkResult, loungeResult, paxStatsByAirlineId, airportChampionInfo, cycle)
+    }
     println("Alliance simulation done")
 
     println("Airplane simulation")
-    val airplanes = AirplaneSimulation.airplaneSimulation(cycle)
+    val airplanes = timed("airplane") {
+      AirplaneSimulation.airplaneSimulation(cycle)
+    }
     println("Airplane simulation done")
 
     println("Airline simulation")
-    AirlineSimulation.airlineSimulation(cycle, flightLinkResult, loungeResult, airplanes, paxStatsByAirlineId)
+    timed("airline") {
+      AirlineSimulation.airlineSimulation(cycle, flightLinkResult, loungeResult, airplanes, paxStatsByAirlineId)
+    }
     println("Airline simulation done")
 
     println("Airplane model simulation")
-    AirplaneModelSimulation.simulate(cycle)
+    timed("airplaneModel") {
+      AirplaneModelSimulation.simulate(cycle)
+    }
     println("Airplane model simulation done")
 
-    //purge history
-    println("Purging link history")
-    ChangeHistorySource.deleteLinkChangeByCriteria(List(("cycle", "<", cycle - 400)))
+    timed("purge") {
+      //purge history
+      println("Purging link history")
+      ChangeHistorySource.deleteLinkChangeByCriteria(List(("cycle", "<", cycle - 400)))
 
-    //purge airline modifier
-    println("Purging airline modifier")
-    AirlineSource.deleteAirlineModifierByExpiry(cycle)
+      //purge airline modifier
+      println("Purging airline modifier")
+      AirlineSource.deleteAirlineModifierByExpiry(cycle)
+    }
 
     val cycleEnd = System.currentTimeMillis()
 
     println(">>>>> cycle " + cycle + " spent " + (cycleEnd - cycleStartTime) / 1000 + " secs")
+    println(">>>>> cycle " + cycle + " phase timings: " + phaseTimings.map { case (name, ms) => s"$name=${ms}ms" }.mkString(", "))
     cycleEnd
   }
 

--- a/docs/single-player-performance-roadmap.md
+++ b/docs/single-player-performance-roadmap.md
@@ -55,10 +55,13 @@ zero players (`MainSimulation.scala`, `CYCLE_DURATION = 60 * 29`).
 - **Per-phase cycle profiler**: log wall time of each phase in
   `MainSimulation.startCycle` (LinkSimulation, AirportSimulation,
   AirlineSimulation, ...) so optimization targets are measured, not guessed.
-- **Targeted cache invalidation**: `MainSimulation` calls `invalidateAll()` on
-  the caches every cycle; airports are effectively static — invalidate only what
-  the cycle actually mutates (statistics, ownership). Carries over the one
-  unfinished item from the old plan.
+- **Targeted cache invalidation — investigated and rejected.** Airports are NOT
+  static from the simulation's point of view: players mutate them (bases,
+  lounges) through the *web JVM*, which has its own cache instances, and the
+  sim's start-of-cycle `invalidateAll()` is what picks those cross-process
+  writes up. Skipping or deferring it would make the sim ignore player actions
+  taken between cycles. A correct fix needs cross-JVM cache invalidation
+  (event-driven over the existing pekko bridge) — deliberately out of scope.
 - **Demand memoization**: `DemandGenerator` recomputes demand from airport
   population/income data that rarely changes; cache the base demand model
   between cycles, recompute on data change only.


### PR DESCRIPTION
PR 3 of 4 from `docs/single-player-performance-roadmap.md` (last one of this phase): measurement tooling so cycle optimization on the OptiPlex targets measured hotspots, not guesses.

## Changes
- Wrap each phase of `MainSimulation.startCycle` (caches, user, event, link, airport, alliance, airplane, airline, airplaneModel, purge) with elapsed-time measurement and emit a one-line per-cycle summary:
  `>>>>> cycle N phase timings: caches=1200ms, link=84000ms, …`
- Roadmap doc: record that **targeted cache invalidation was investigated and rejected** — players mutate airports through the web JVM (separate cache instances), and the sim's start-of-cycle `invalidateAll()` is what picks up those cross-process writes; skipping it would make the sim ignore player actions taken between cycles.

## Validation
- `airline-data` compiles; behavior unchanged apart from the extra log line
- On-box (deferred until the OptiPlex test setup): per-phase timings + the MySQL slow-query log from #19 form the Phase 0 baseline in `docs/performance-baseline.md`

https://claude.ai/code/session_01SWKFjtc6iiSApwuJQyPNYU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWKFjtc6iiSApwuJQyPNYU)_