### PR TITLE
feat(ci): OptiPlex self-hosted deploy pipeline

### DIFF
--- a/.docker/data/start.sh
+++ b/.docker/data/start.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 echo "===== START OF BACKEND ====="
 cd /home/airline/airline/airline-data
-SBT_OPTS="-Xmx1536M -Xms512M -XX:MaxMetaspaceSize=512M" sbt "runMain com.patson.MainSimulation"
+SBT_OPTS="-Xmx1536M -Xms512M -XX:MaxMetaspaceSize=512M ${SIM_EXTRA_OPTS:-}" sbt "runMain com.patson.MainSimulation"
 echo "===== BACKEND SHUTDOWN WITH CODE $? ====="

--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -1,0 +1,62 @@
+name: OptiPlex Deploy & Verify
+
+# workflow_dispatch only until the first successful run; then add
+#   push: { branches: [master] }
+# per docs/optiplex-ci-plan.md. Never trigger on pull_request — this runs
+# on a self-hosted runner.
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: optiplex-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, optiplex]
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Keep sbt/ivy build artifacts between runs for faster deploys.
+          clean: false
+
+      - name: Deploy stack
+        env:
+          SIM_EXTRA_OPTS: -Dsimulation.pauseWhenIdle=true
+        run: bash scripts/optiplex-deploy.sh
+
+      - name: Install e2e dependencies
+        run: |
+          npm ci --prefix e2e
+          npx --prefix e2e playwright install chromium
+
+      - name: Run Playwright tests
+        run: npm test --prefix e2e
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: |
+            e2e/test-results
+            e2e/playwright-report
+          if-no-files-found: ignore
+
+      - name: Collect logs and job summary
+        if: always()
+        run: |
+          {
+            echo "## Container resource usage"
+            echo '```'
+            docker stats --no-stream || true
+            echo '```'
+            echo "## Simulation log (cycle timings, last 40 lines)"
+            echo '```'
+            docker exec airline-app sh -c 'grep -i cycle /home/airline/sim.log | tail -40' \
+              || docker exec airline-app sh -c 'tail -40 /home/airline/sim.log' \
+              || echo "no sim log"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docker-compose.small.yaml
+++ b/docker-compose.small.yaml
@@ -25,6 +25,11 @@ services:
     environment:
       DB_HOST: airline-db
     entrypoint: ["tail", "-f", "/dev/null"]
+    # Required for docker inside an unprivileged LXC, where securityfs is
+    # unreadable and the docker-default AppArmor profile can never load.
+    # No-op on hosts without AppArmor.
+    security_opt:
+      - apparmor=unconfined
     mem_limit: 3500m
     ports:
       - "9000:9000"
@@ -42,6 +47,8 @@ services:
     # the frozen archive of the same image.
     image: bitnamilegacy/mysql:8.0
     container_name: airline-db
+    security_opt:
+      - apparmor=unconfined
     environment:
       MYSQL_DATABASE: airline
       MYSQL_USER: mfc01

--- a/docker-compose.small.yaml
+++ b/docker-compose.small.yaml
@@ -38,7 +38,9 @@ services:
       - airline
 
   airline-db:
-    image: bitnami/mysql:8.0
+    # bitnami/ images were removed from Docker Hub in 2025; bitnamilegacy is
+    # the frozen archive of the same image.
+    image: bitnamilegacy/mysql:8.0
     container_name: airline-db
     environment:
       MYSQL_DATABASE: airline

--- a/scripts/optiplex-deploy.sh
+++ b/scripts/optiplex-deploy.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Idempotent deploy of the small-server stack on the OptiPlex runner.
+# Brings up docker-compose.small.yaml, initializes the database on first
+# run only, restarts the simulation and web processes, and waits for the
+# web frontend to answer on :9000. See docs/optiplex-ci-plan.md.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+COMPOSE="docker compose -f docker-compose.small.yaml"
+SIM_EXTRA_OPTS="${SIM_EXTRA_OPTS:-}"
+
+# Containers with our fixed names left behind by an older compose project
+# (different working dir) block `up` with a name conflict. Only stopped
+# containers are reclaimed; volumes are never touched.
+for name in airline-app airline-db; do
+  state=$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || true)
+  if [ -n "$state" ] && [ "$state" != "running" ]; then
+    project_dir=$(docker inspect -f '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' "$name")
+    if [ "$project_dir" != "$(pwd)" ]; then
+      echo "==> Removing stale stopped container $name (from $project_dir)"
+      docker rm "$name"
+    fi
+  fi
+done
+
+echo "==> Starting containers"
+$COMPOSE up -d --build
+
+echo "==> Waiting for MySQL (up to 60s)"
+db_ready=""
+for _ in $(seq 1 60); do
+  if docker exec airline-db mysqladmin ping --silent 2>/dev/null; then
+    db_ready=1
+    break
+  fi
+  sleep 1
+done
+if [ -z "$db_ready" ]; then
+  echo "ERROR: MySQL did not become ready within 60s" >&2
+  docker logs --tail 50 airline-db >&2 || true
+  exit 1
+fi
+
+echo "==> Stopping any prior simulation/web processes"
+docker exec airline-app sh -c '
+  for p in /proc/[0-9]*; do
+    pid=${p#/proc/}
+    [ "$pid" = 1 ] && continue
+    cmd=$(tr "\0" " " < "$p/cmdline" 2>/dev/null || true)
+    case "$cmd" in
+      *sbt*|*java*) kill "$pid" 2>/dev/null || true ;;
+    esac
+  done
+  true'
+sleep 3
+
+# Credentials come from the compose file via the running container's env.
+DB_USER=$(docker exec airline-db printenv MYSQL_USER)
+DB_PASS=$(docker exec airline-db printenv MYSQL_PASSWORD)
+DB_NAME=$(docker exec airline-db printenv MYSQL_DATABASE)
+
+cycle_table=$(docker exec airline-db mysql -u"$DB_USER" -p"$DB_PASS" -N \
+  -e "SHOW TABLES LIKE 'cycle'" "$DB_NAME" 2>/dev/null || true)
+if [ -z "$cycle_table" ]; then
+  echo "==> Database not initialized; running init (publishLocal + MainInit)"
+  docker exec airline-app sh /home/airline/init-data.sh
+else
+  echo "==> Database already initialized; refreshing airline-data artifact"
+  docker exec airline-app sh -c \
+    'cd /home/airline/airline/airline-data && SBT_OPTS="-Xmx1536M -Xms512M -XX:MaxMetaspaceSize=512M" sbt publishLocal'
+fi
+
+echo "==> Starting simulation (SIM_EXTRA_OPTS='$SIM_EXTRA_OPTS') and web"
+docker exec -d -e SIM_EXTRA_OPTS="$SIM_EXTRA_OPTS" airline-app \
+  sh -c 'sh /home/airline/start-data.sh > /home/airline/sim.log 2>&1'
+docker exec -d airline-app \
+  sh -c 'sh /home/airline/start-web.sh > /home/airline/web.log 2>&1'
+
+echo "==> Waiting for HTTP 200 from :9000 (up to 10 min)"
+web_ready=""
+for _ in $(seq 1 120); do
+  if curl -sf -o /dev/null http://localhost:9000/; then
+    web_ready=1
+    break
+  fi
+  sleep 5
+done
+if [ -z "$web_ready" ]; then
+  echo "ERROR: web frontend did not answer on :9000 within 10 minutes" >&2
+  docker exec airline-app sh -c 'tail -50 /home/airline/web.log' >&2 || true
+  exit 1
+fi
+
+echo "==> Deploy complete: http://localhost:9000 is up"


### PR DESCRIPTION
Implements part 3 of docs/optiplex-ci-plan.md:

- `scripts/optiplex-deploy.sh` — idempotent deploy: compose up, MySQL health wait, init only when the `cycle` table is absent, kill prior sbt/java processes, restart simulation + web, wait for HTTP 200 on :9000. DB credentials are read from the running `airline-db` container env (sourced from the compose file — no secrets in the script).
- `.docker/data/start.sh` — appends `$SIM_EXTRA_OPTS` to SBT_OPTS so the workflow can enable `simulation.pauseWhenIdle` without touching upstream config.
- `.github/workflows/optiplex-deploy.yml` — `workflow_dispatch`-only deploy + Playwright verification on the self-hosted `optiplex` runner, with concurrency guard, failure artifacts, and a resource/cycle-timing job summary.

Runner `airline-dev-optiplex` (label `optiplex`) is already registered and online in LXC 202 (airline-dev) on pve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)