### PR TITLE
feat(compose): restart policy for reboot survival

### DIFF
--- a/docker-compose.small.yaml
+++ b/docker-compose.small.yaml
@@ -11,6 +11,7 @@ volumes:
 services:
   airline-app:
     container_name: airline-app
+    restart: unless-stopped
     build:
       context: .
       dockerfile: .docker/Dockerfile
@@ -47,6 +48,7 @@ services:
     # the frozen archive of the same image.
     image: bitnamilegacy/mysql:8.0
     container_name: airline-db
+    restart: unless-stopped
     security_opt:
       - apparmor=unconfined
     environment:


### PR DESCRIPTION
Adds `restart: unless-stopped` to both small-profile services per the reboot-survival acceptance criterion in docs/optiplex-ci-plan.md. Merging this triggers the push deploy as further validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)