### PR TITLE
fix(compose): reap healthcheck zombies via init: true

### DIFF
--- a/docker-compose.small.yaml
+++ b/docker-compose.small.yaml
@@ -12,6 +12,9 @@ services:
   airline-app:
     container_name: airline-app
     restart: unless-stopped
+    # PID 1 is `tail`, which never reaps the healthcheck's curl zombies;
+    # tini does.
+    init: true
     build:
       context: .
       dockerfile: .docker/Dockerfile


### PR DESCRIPTION
`ps` inside airline-app shows accumulating `[curl] <defunct>` processes — the healthcheck curl is orphaned to PID 1 (`tail -f /dev/null`), which never reaps. `init: true` puts tini at PID 1. Merge triggers the push deploy as validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)