### PR TITLE
feat(deploy): disable pause-when-idle on OptiPlex

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -24,8 +24,6 @@ jobs:
           clean: false
 
       - name: Deploy stack
-        env:
-          SIM_EXTRA_OPTS: -Dsimulation.pauseWhenIdle=true
         run: bash scripts/optiplex-deploy.sh
 
       - name: Install e2e dependencies


### PR DESCRIPTION
Per owner decision: with a fixed 29-minute cycle, pausing while idle makes a returning player wait up to a full cycle before anything progresses. Drops `SIM_EXTRA_OPTS=-Dsimulation.pauseWhenIdle=true` from the deploy workflow; the capability remains available behind the flag. Merge triggers the redeploy that restarts the sim unpaused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)