### PR TITLE
feat(sim): player-controlled sim speed and fast-forward

### DIFF
--- a/airline-data/src/main/scala/com/patson/MainSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/MainSimulation.scala
@@ -15,6 +15,8 @@ import scala.concurrent.duration.Duration
 
 object MainSimulation extends App {
   val CYCLE_DURATION : Int = 60 * 29
+  val MIN_CYCLE_MINUTES : Int = 5 //roughly cycle compute time + DB rest buffer
+  val MAX_CYCLE_MINUTES : Int = 24 * 60
   val SCHEDULE_BUFFER_SECS : Int = 30
   val SCHEDULE_OVERHEAD_FACTOR : Double = 1.1
   var currentWeek: Int = 0
@@ -23,6 +25,38 @@ object MainSimulation extends App {
   val pauseWhenIdle : Boolean = Constants.configFactory.hasPath("simulation.pauseWhenIdle") && Constants.configFactory.getBoolean("simulation.pauseWhenIdle")
   val idleGraceMinutes : Long = if (Constants.configFactory.hasPath("simulation.idleGraceMinutes")) Constants.configFactory.getLong("simulation.idleGraceMinutes") else 60
   val idleRecheckMinutes : Long = if (Constants.configFactory.hasPath("simulation.idleRecheckMinutes")) Constants.configFactory.getLong("simulation.idleRecheckMinutes") else 5
+
+  //player-adjustable pacing (written by the web app into the sim_control table)
+  def configuredCycleIntervalMs() : Long = {
+    try {
+      SimControlSource.loadCycleMinutes() match {
+        case Some(minutes) => Math.max(MIN_CYCLE_MINUTES, Math.min(MAX_CYCLE_MINUTES, minutes)) * 60000L
+        case None => CYCLE_DURATION * 1000L
+      }
+    } catch {
+      case e : Exception =>
+        println(s"Failed to read sim control (${e.getMessage}), using default cycle duration")
+        CYCLE_DURATION * 1000L
+    }
+  }
+
+  def consumeFastForward() : Boolean = {
+    try {
+      SimControlSource.consumeFastForward()
+    } catch {
+      case e : Exception =>
+        println(s"Failed to read fast-forward request (${e.getMessage})")
+        false
+    }
+  }
+
+  def fastForwardPending() : Boolean = {
+    try {
+      SimControlSource.loadFastForward() > 0
+    } catch {
+      case _ : Exception => false
+    }
+  }
 
   def isIdle() : Boolean = {
     try {
@@ -166,6 +200,7 @@ object MainSimulation extends App {
   case object ExecuteProcessing
   case object BroadcastAndAdvance
   case object ScheduleNext
+  case object CheckFastForward
 
   /**
     * The simulation can be seen like this:
@@ -175,34 +210,55 @@ object MainSimulation extends App {
     *
     */
   class MainSimulationActor extends Actor {
-    val CYCLE_INTERVAL_MS = CYCLE_DURATION * 1000L
     val DB_REST_BUFFER_MS = SCHEDULE_BUFFER_SECS * 1000L
 
     var currentWeek = CycleSource.loadCycle()
     var lastExecutionMs: Long = 0L
     var targetDeadline: Long = 0L // In-memory dynamic deadline
+    var scheduledWakeUp: Option[org.apache.pekko.actor.Cancellable] = None
+
+    private def scheduleExecution(delayMs : Long) : Unit = {
+      scheduledWakeUp.foreach(_.cancel())
+      scheduledWakeUp = Some(context.system.scheduler.scheduleOnce(Duration(delayMs, TimeUnit.MILLISECONDS), self, ExecuteProcessing))
+    }
 
     override def preStart(): Unit = {
       // First run executes immediately to update users ASAP
-      context.system.scheduler.scheduleOnce(Duration.Zero, self, ExecuteProcessing)
+      scheduleExecution(0L)
+      // While waiting for the next deadline, notice player fast-forward requests promptly
+      context.system.scheduler.scheduleWithFixedDelay(Duration(30, TimeUnit.SECONDS), Duration(30, TimeUnit.SECONDS), self, CheckFastForward)
     }
 
     def receive = {
       case ScheduleNext =>
         status = SimulationStatus.WAITING_CYCLE_START
-        val estimatedExecution = (lastExecutionMs * SCHEDULE_OVERHEAD_FACTOR).toLong
-        val leadTime = estimatedExecution + DB_REST_BUFFER_MS
+        if (consumeFastForward()) {
+          println("Fast-forward requested: starting next cycle immediately")
+          targetDeadline = System.currentTimeMillis() //broadcast right after compute instead of waiting for the deadline
+          scheduleExecution(DB_REST_BUFFER_MS)
+        } else {
+          val estimatedExecution = (lastExecutionMs * SCHEDULE_OVERHEAD_FACTOR).toLong
+          val leadTime = estimatedExecution + DB_REST_BUFFER_MS
 
-        val wakeUpTime = targetDeadline - leadTime
-        val delayUntilWakeUp = Math.max(0L, wakeUpTime - System.currentTimeMillis())
+          val wakeUpTime = targetDeadline - leadTime
+          val delayUntilWakeUp = Math.max(0L, wakeUpTime - System.currentTimeMillis())
 
-        println(s"Next cycle will wake up in ${delayUntilWakeUp / 1000}s (estimated exec: ${estimatedExecution / 1000}s)")
-        context.system.scheduler.scheduleOnce(Duration(delayUntilWakeUp, TimeUnit.MILLISECONDS), self, ExecuteProcessing)
+          println(s"Next cycle will wake up in ${delayUntilWakeUp / 1000}s (estimated exec: ${estimatedExecution / 1000}s)")
+          scheduleExecution(delayUntilWakeUp)
+        }
 
-      case ExecuteProcessing if pauseWhenIdle && isIdle() =>
+      case CheckFastForward =>
+        //a player asked to fast-forward while we are waiting for the next deadline: run now instead
+        if (status == SimulationStatus.WAITING_CYCLE_START && consumeFastForward()) {
+          println("Fast-forward requested: cancelling scheduled wait and starting cycle now")
+          targetDeadline = System.currentTimeMillis() //broadcast right after compute instead of waiting for the deadline
+          scheduleExecution(0L)
+        }
+
+      case ExecuteProcessing if pauseWhenIdle && isIdle() && !fastForwardPending() =>
         status = SimulationStatus.WAITING_CYCLE_START
         println(s"Simulation paused: no player activity within the last $idleGraceMinutes min. Rechecking in $idleRecheckMinutes min")
-        context.system.scheduler.scheduleOnce(Duration(idleRecheckMinutes, TimeUnit.MINUTES), self, ExecuteProcessing)
+        scheduleExecution(idleRecheckMinutes * 60000L)
 
       case ExecuteProcessing =>
         status = SimulationStatus.IN_PROGRESS
@@ -229,7 +285,7 @@ object MainSimulation extends App {
           case e : Exception =>
             println(s"!!!!!!! Cycle $currentWeek failed with exception: ${e.getClass.getSimpleName}: ${e.getMessage}. Retrying in 60s.")
             status = SimulationStatus.WAITING_CYCLE_START
-            context.system.scheduler.scheduleOnce(Duration(60, TimeUnit.SECONDS), self, ExecuteProcessing)
+            scheduleExecution(60000L)
         }
 
       case BroadcastAndAdvance =>
@@ -240,7 +296,7 @@ object MainSimulation extends App {
         currentWeek += 1
         CycleSource.setCycle(currentWeek)
 
-        targetDeadline = System.currentTimeMillis() + CYCLE_INTERVAL_MS
+        targetDeadline = System.currentTimeMillis() + configuredCycleIntervalMs()
         self ! ScheduleNext
     }
   }

--- a/airline-data/src/main/scala/com/patson/data/SimControlSource.scala
+++ b/airline-data/src/main/scala/com/patson/data/SimControlSource.scala
@@ -1,0 +1,85 @@
+package com.patson.data
+
+import java.sql.Connection
+import scala.util.Using
+
+/**
+  * Player-adjustable simulation pacing. Written by the web app and read by the
+  * simulation scheduler (see MainSimulation): `cycle_minutes` is the target
+  * wall-clock length of one game week, and `fast_forward` is a count of extra
+  * cycles to run back-to-back without waiting for the deadline.
+  *
+  * The table is created lazily so no migration is required on existing databases.
+  */
+object SimControlSource {
+  val SIM_CONTROL_TABLE = "sim_control"
+
+  @volatile private var tableEnsured = false
+
+  private def ensureTable(connection : Connection) : Unit = {
+    if (!tableEnsured) {
+      Using.resource(connection.prepareStatement("CREATE TABLE IF NOT EXISTS " + SIM_CONTROL_TABLE + "(id INTEGER PRIMARY KEY, cycle_minutes INTEGER NOT NULL, fast_forward INTEGER NOT NULL DEFAULT 0)")) { statement =>
+        statement.execute()
+      }
+      tableEnsured = true
+    }
+  }
+
+  def loadCycleMinutes() : Option[Int] = {
+    Using.resource(Meta.getConnection()) { connection =>
+      ensureTable(connection)
+      Using.resource(connection.prepareStatement("SELECT cycle_minutes FROM " + SIM_CONTROL_TABLE + " WHERE id = 1")) { statement =>
+        Using.resource(statement.executeQuery()) { resultSet =>
+          if (resultSet.next()) Some(resultSet.getInt("cycle_minutes")) else None
+        }
+      }
+    }
+  }
+
+  def loadFastForward() : Int = {
+    Using.resource(Meta.getConnection()) { connection =>
+      ensureTable(connection)
+      Using.resource(connection.prepareStatement("SELECT fast_forward FROM " + SIM_CONTROL_TABLE + " WHERE id = 1")) { statement =>
+        Using.resource(statement.executeQuery()) { resultSet =>
+          if (resultSet.next()) resultSet.getInt("fast_forward") else 0
+        }
+      }
+    }
+  }
+
+  def setCycleMinutes(minutes : Int) : Unit = {
+    Using.resource(Meta.getConnection()) { connection =>
+      ensureTable(connection)
+      Using.resource(connection.prepareStatement("INSERT INTO " + SIM_CONTROL_TABLE + "(id, cycle_minutes) VALUES(1, ?) ON DUPLICATE KEY UPDATE cycle_minutes = ?")) { statement =>
+        statement.setInt(1, minutes)
+        statement.setInt(2, minutes)
+        statement.executeUpdate()
+      }
+    }
+  }
+
+  def setFastForward(cycles : Int, defaultCycleMinutes : Int) : Unit = {
+    Using.resource(Meta.getConnection()) { connection =>
+      ensureTable(connection)
+      Using.resource(connection.prepareStatement("INSERT INTO " + SIM_CONTROL_TABLE + "(id, cycle_minutes, fast_forward) VALUES(1, ?, ?) ON DUPLICATE KEY UPDATE fast_forward = ?")) { statement =>
+        statement.setInt(1, defaultCycleMinutes)
+        statement.setInt(2, cycles)
+        statement.setInt(3, cycles)
+        statement.executeUpdate()
+      }
+    }
+  }
+
+  /**
+    * Atomically consumes one pending fast-forward cycle.
+    * @return true if one was consumed (caller should run a cycle immediately)
+    */
+  def consumeFastForward() : Boolean = {
+    Using.resource(Meta.getConnection()) { connection =>
+      ensureTable(connection)
+      Using.resource(connection.prepareStatement("UPDATE " + SIM_CONTROL_TABLE + " SET fast_forward = fast_forward - 1 WHERE id = 1 AND fast_forward > 0")) { statement =>
+        statement.executeUpdate() == 1
+      }
+    }
+  }
+}

--- a/airline-web/app/controllers/SimControlApplication.scala
+++ b/airline-web/app/controllers/SimControlApplication.scala
@@ -17,9 +17,11 @@ class SimControlApplication @Inject()(cc: ControllerComponents) extends Abstract
   val MAX_FAST_FORWARD = 52
 
   def getSimControl() = Authenticated { implicit request =>
+    val defaultCycleMinutes : Int = MainSimulation.CYCLE_DURATION / 60
+    val cycleMinutes : Int = SimControlSource.loadCycleMinutes().getOrElse(defaultCycleMinutes)
     Ok(Json.obj(
-      "cycleMinutes" -> SimControlSource.loadCycleMinutes().getOrElse(MainSimulation.CYCLE_DURATION / 60),
-      "defaultCycleMinutes" -> MainSimulation.CYCLE_DURATION / 60,
+      "cycleMinutes" -> cycleMinutes,
+      "defaultCycleMinutes" -> defaultCycleMinutes,
       "minCycleMinutes" -> MainSimulation.MIN_CYCLE_MINUTES,
       "maxCycleMinutes" -> MainSimulation.MAX_CYCLE_MINUTES,
       "fastForward" -> SimControlSource.loadFastForward(),

--- a/airline-web/app/controllers/SimControlApplication.scala
+++ b/airline-web/app/controllers/SimControlApplication.scala
@@ -1,0 +1,42 @@
+package controllers
+
+import controllers.AuthenticationObject.Authenticated
+import com.patson.MainSimulation
+import com.patson.data.SimControlSource
+import play.api.libs.json._
+import play.api.mvc._
+
+import javax.inject.Inject
+
+/**
+  * Player control over simulation pacing: target minutes per game week and
+  * fast-forward (run N cycles back-to-back). Writes the sim_control table,
+  * which the simulation scheduler polls (see MainSimulation).
+  */
+class SimControlApplication @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+  val MAX_FAST_FORWARD = 52
+
+  def getSimControl() = Authenticated { implicit request =>
+    Ok(Json.obj(
+      "cycleMinutes" -> SimControlSource.loadCycleMinutes().getOrElse(MainSimulation.CYCLE_DURATION / 60),
+      "defaultCycleMinutes" -> MainSimulation.CYCLE_DURATION / 60,
+      "minCycleMinutes" -> MainSimulation.MIN_CYCLE_MINUTES,
+      "maxCycleMinutes" -> MainSimulation.MAX_CYCLE_MINUTES,
+      "fastForward" -> SimControlSource.loadFastForward(),
+      "maxFastForward" -> MAX_FAST_FORWARD))
+  }
+
+  def setCycleMinutes(minutes : Int) = Authenticated { implicit request =>
+    val clamped = Math.max(MainSimulation.MIN_CYCLE_MINUTES, Math.min(MainSimulation.MAX_CYCLE_MINUTES, minutes))
+    SimControlSource.setCycleMinutes(clamped)
+    println(s"User ${request.user.userName} set simulation cycle length to $clamped min")
+    Ok(Json.obj("cycleMinutes" -> clamped))
+  }
+
+  def fastForward(cycles : Int) = Authenticated { implicit request =>
+    val clamped = Math.max(0, Math.min(MAX_FAST_FORWARD, cycles))
+    SimControlSource.setFastForward(clamped, MainSimulation.CYCLE_DURATION / 60)
+    println(s"User ${request.user.userName} requested fast-forward of $clamped cycle(s)")
+    Ok(Json.obj("fastForward" -> clamped))
+  }
+}

--- a/airline-web/app/views/fragments/navbar.scala.html
+++ b/airline-web/app/views/fragments/navbar.scala.html
@@ -20,6 +20,7 @@
         <div class="topBarDetails">
             <p class="currentTime label tooltip-attr tooltip-attr-bottom desktopOnly" data-tooltip="One week lasts ~ 30min and one year is 48 weeks or 24 hours in realtime. "></p>
             <p class="tooltip-attr tooltip-attr-bottom desktopOnly" data-tooltip="An estimate of how long until next week."><img src='@routes.Assets.versioned("/images/icons/clock-moon-phase.png")' style="vertical-align: middle;"><span class="nextTickEstimation label" style="font-weight: bold;">Estimating...</span></p>
+            <p class="desktopOnly"><span class="clickable label tooltip-attr tooltip-attr-bottom" data-tooltip="Change simulation speed (minutes per game week)" onclick="promptSimSpeed()">&#9881;</span> <span class="clickable label tooltip-attr tooltip-attr-bottom" data-tooltip="Fast-forward: run the next N weeks back-to-back" onclick="promptFastForward()">&#9193;</span></p>
             <p class="tooltip-attr tooltip-attr-bottom" data-tooltip="Cash money">$<span class="balance"></span></p>
             <p class="tooltip-attr tooltip-attr-bottom actionPoints" data-tooltip="Action Points"></p>
             <div id="notificationBell" class="clickable relative pr-4" title="Notifications">

--- a/airline-web/conf/routes
+++ b/airline-web/conf/routes
@@ -14,6 +14,9 @@ GET		 /api/:version/game/tooltips			  controllers.Application.getTooltips(versio
 POST	 /user-login							  controllers.UserApplication.login
 POST	 /user-logout						  controllers.UserApplication.logout
 GET      /current-cycle                   controllers.Application.getCurrentCycle()
+GET      /sim-control                     controllers.SimControlApplication.getSimControl()
+PUT      /sim-control/cycle-minutes/:minutes		controllers.SimControlApplication.setCycleMinutes(minutes : Int)
+PUT      /sim-control/fast-forward/:cycles		controllers.SimControlApplication.fastForward(cycles : Int)
 
 GET		 /airports						  controllers.Application.getAirports()
 GET		 /api/:version/airports-static						  controllers.Application.getAirportsStatic(version: String)

--- a/airline-web/public/javascripts/main.js
+++ b/airline-web/public/javascripts/main.js
@@ -159,6 +159,46 @@ var days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 var currentTickTimer
 var tickTimerCreator
 
+function promptSimSpeed() {
+	$.ajax({
+		type: 'GET',
+		url: "sim-control",
+		dataType: 'json',
+		success: function(control) {
+			var input = prompt("Minutes per game week (" + control.minCycleMinutes + " - " + control.maxCycleMinutes + ", default " + control.defaultCycleMinutes + "):", control.cycleMinutes)
+			if (input === null) { return }
+			var minutes = parseInt(input)
+			if (isNaN(minutes)) { return }
+			$.ajax({
+				type: 'PUT',
+				url: "sim-control/cycle-minutes/" + minutes,
+				dataType: 'json',
+				success: function(result) {
+					alert("Simulation speed set to " + result.cycleMinutes + " minutes per week (takes effect after the current week)")
+				},
+				error: function() { alert("Please log in to change the simulation speed") }
+			})
+		},
+		error: function() { alert("Please log in to change the simulation speed") }
+	})
+}
+
+function promptFastForward() {
+	var input = prompt("Fast-forward how many weeks (run back-to-back, 1 - 52)?", "1")
+	if (input === null) { return }
+	var cycles = parseInt(input)
+	if (isNaN(cycles)) { return }
+	$.ajax({
+		type: 'PUT',
+		url: "sim-control/fast-forward/" + cycles,
+		dataType: 'json',
+		success: function(result) {
+			alert("Fast-forwarding " + result.fastForward + " week(s) starting after the current week completes")
+		},
+		error: function() { alert("Please log in to fast-forward the simulation") }
+	})
+}
+
 function updateTime(cycle, fraction, cycleDurationEstimation) {
 	$(".currentTime").attr("data-tooltip", "Week " + cycle % 48 + " & Year " + Math.floor(cycle / 48) + " | One week lasts ~ 30min and one year is 48 weeks or 24 hours in realtime.")
 	gameTimeStart = (cycle + fraction) * totalmillisecPerWeek


### PR DESCRIPTION
Implements both player pacing controls discussed:

- **Adjustable cycle length** — minutes per game week (5–1440, default 29), stored in a new lazily-created `sim_control` table, read by the scheduler when it computes the next deadline.
- **Fast-forward** — run the next N weeks (≤52) back-to-back with only the 30s DB-rest buffer between cycles. A 30s poll in the sim actor notices requests made mid-wait, cancels the scheduled wake-up, pulls the broadcast deadline in, and starts immediately — so the first fast cycle begins within ~30s of the click.
- **Web UI** — gear (speed) and fast-forward buttons in the navbar next to the cycle countdown; authenticated endpoints `GET /sim-control`, `PUT /sim-control/cycle-minutes/:minutes`, `PUT /sim-control/fast-forward/:cycles`.
- Fast-forward overrides pause-when-idle if that flag is ever re-enabled.

Follows the activity_heartbeat pattern (web writes DB, sim polls) — no new infrastructure, survives restarts, no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)