### PR TITLE
fix(sim): G1GC + larger heap for full-cycle completion on small server

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -24,6 +24,9 @@ jobs:
           clean: false
 
       - name: Deploy stack
+        env:
+          # Full-dataset cycles need more than the start script's 1.5G default.
+          SIM_EXTRA_OPTS: -Xmx2048M
         run: bash scripts/optiplex-deploy.sh
 
       - name: Install e2e dependencies

--- a/airline-data/.sbtopts
+++ b/airline-data/.sbtopts
@@ -3,9 +3,10 @@
 -J-Xmx8G
 -J-Xms8G
 
-# GC Settings for Max Throughput (Parallel Collector)
--J-XX:+UseParallelGC
--J-XX:ParallelGCThreads=8
+# GC: G1 keeps pauses bounded and, unlike the parallel collector, degrades
+# gracefully instead of entering a full-GC death spiral when the heap is
+# constrained (e.g. the small-server profile overrides Xmx down to ~2G).
+-J-XX:+UseG1GC
 
 # Metaspace
 -J-XX:MetaspaceSize=256M

--- a/docker-compose.small.yaml
+++ b/docker-compose.small.yaml
@@ -34,7 +34,8 @@ services:
     # No-op on hosts without AppArmor.
     security_opt:
       - apparmor=unconfined
-    mem_limit: 3500m
+    # Holds both the simulation JVM (~2G heap) and the web JVM (~1G heap).
+    mem_limit: 4096m
     ports:
       - "9000:9000"
     healthcheck:


### PR DESCRIPTION
Removing pause-when-idle (#31) exposed a latent capacity problem: the simulation never actually computed a full-dataset cycle on the OptiPlex. With the parallel collector and the small-server 1.5G heap override, cycle 1 went into a full-GC death spiral (>90% time in GC, heap pinned at 1.45G) and never completed — pause-when-idle had been masking it by bailing out before any cycle ran.

- `airline-data/.sbtopts`: ParallelGC → G1GC (degrades gracefully under heap pressure instead of full-GC thrashing; the JVM itself logged this recommendation).
- `SIM_EXTRA_OPTS=-Xmx2048M` in the deploy: raise the sim heap from 1.5G to 2G.
- app container `mem_limit` 3500m → 4096m to hold the 2G sim + 1G web JVMs.

Host `pve` is memory-constrained (other guests own ~10G of 16G), so this is a deliberately modest bump rather than the .sbtopts 8G. If a full cycle still cannot complete in 2G, the realistic options are freeing host RAM or relocating the stack — noted for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)