### PR TITLE
feat(solo): configurable economy constants (Step A)

### DIFF
--- a/airline-data/src/main/resources/application.conf
+++ b/airline-data/src/main/resources/application.conf
@@ -44,3 +44,17 @@ hikari.connectionTimeout = 90000
 # simulation.pauseWhenIdle = true
 # simulation.idleGraceMinutes = 60
 # simulation.idleRecheckMinutes = 5
+
+# Single-player economy tuning (see com.patson.data.SoloConfig). Every key
+# defaults to the upstream value, so leaving them unset is identical to vanilla.
+# Set on the relevant process (these read whichever config the JVM loaded, and
+# also honor -Dsolo.* system properties):
+#   simulation process: ap / loan / bankruptcy keys
+#   web process (sign-up): startingBalance / minRenewalBalance
+# solo.startingBalance = 25000000          # new airline starting cash (default 0)
+# solo.minRenewalBalance = 100000          # default 300000
+# solo.ap.generationRate = 0.3             # action points/week/manager (default 0.1)
+# solo.ap.maxCyclesStored = 96             # default 96 (24*4)
+# solo.loan.defaultAnnualRate = 0.06       # default 0.11
+# solo.bankruptcy.cashThreshold = -25000000   # default -10000000
+# solo.bankruptcy.assetsThreshold = -150000000 # default -100000000

--- a/airline-data/src/main/scala/com/patson/data/GameConstants.scala
+++ b/airline-data/src/main/scala/com/patson/data/GameConstants.scala
@@ -4,8 +4,8 @@ import com.patson.model.Airport
 import com.patson.LoanInterestRateSimulation
 
 object GameConstants {
-  val BANKRUPTCY_ASSETS_THRESHOLD = -100_000_000 //-100m
-  val BANKRUPTCY_CASH_THRESHOLD = -10_000_000 //-10M
+  val BANKRUPTCY_ASSETS_THRESHOLD = SoloConfig.bankruptcyAssetsThreshold //default -100m
+  val BANKRUPTCY_CASH_THRESHOLD = SoloConfig.bankruptcyCashThreshold //default -10M
   val TOOLTIP_BANKRUPTCY = List(
     s"If your airline has less than ${String.format("%,d", BANKRUPTCY_CASH_THRESHOLD)} cash and less than ${String.format("%,d", BANKRUPTCY_ASSETS_THRESHOLD)} in asset value, your airline will go through bankruptcy and all your assets will be sold.",
     s"When you have a negative cash balance, you are charged a ${LoanInterestRateSimulation.HIGH_RATE_THRESHOLD * 100}% interest rate on your balance."

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -1,0 +1,33 @@
+package com.patson.data
+
+/**
+  * Single-player tuning knobs. Every value defaults to the current upstream
+  * constant, so default/multiplayer deploys are unchanged. A single-player host
+  * opts in by setting the `solo.*` keys via system properties
+  * (e.g. SBT_OPTS="-Dsolo.startingBalance=25000000") or application.conf.
+  *
+  * Read once at startup from the same loaded config as the rest of the game
+  * (Constants.configFactory, which includes -D system properties).
+  */
+object SoloConfig {
+  private val config = Constants.configFactory
+
+  private def longAt(path : String, default : Long) : Long = if (config.hasPath(path)) config.getLong(path) else default
+  private def intAt(path : String, default : Int) : Int = if (config.hasPath(path)) config.getInt(path) else default
+  private def doubleAt(path : String, default : Double) : Double = if (config.hasPath(path)) config.getDouble(path) else default
+
+  // New-player economy (consumed by airline-web SignUp)
+  val startingBalance : Long = longAt("solo.startingBalance", 0L)
+  val minRenewalBalance : Long = longAt("solo.minRenewalBalance", 300000L)
+
+  // Action-point generation (ManagerBaseTask / ManagerSimulation)
+  val apGenerationRate : Double = doubleAt("solo.ap.generationRate", 0.1)
+  val apMaxCyclesStored : Int = intAt("solo.ap.maxCyclesStored", 24 * 4)
+
+  // Loans (Bank)
+  val loanDefaultAnnualRate : Double = doubleAt("solo.loan.defaultAnnualRate", 0.11)
+
+  // Bankruptcy thresholds (GameConstants / AirlineSimulation)
+  val bankruptcyCashThreshold : Int = intAt("solo.bankruptcy.cashThreshold", -10_000_000)
+  val bankruptcyAssetsThreshold : Int = intAt("solo.bankruptcy.assetsThreshold", -100_000_000)
+}

--- a/airline-data/src/main/scala/com/patson/model/Bank.scala
+++ b/airline-data/src/main/scala/com/patson/model/Bank.scala
@@ -12,7 +12,7 @@ object Bank {
   val MIN_LOAN_AMOUNT = 10000
   val MAX_LOAN_AMOUNT : Long = 10000000000L //10b max
   val LOAN_REAPPLY_MIN_INTERVAL = 2
-  val DEFAULT_ANNUAL_RATE = 0.11
+  val DEFAULT_ANNUAL_RATE = com.patson.data.SoloConfig.loanDefaultAnnualRate
   def getMaxLoan(airlineId : Int) : LoanReply = {
     val existingLoans = BankSource.loadLoansByAirline(airlineId)
     

--- a/airline-data/src/main/scala/com/patson/model/Manager.scala
+++ b/airline-data/src/main/scala/com/patson/model/Manager.scala
@@ -84,9 +84,9 @@ case class ManagerBaseTask() extends ManagerTask(0, ManagerTaskType.MANAGER_BASE
 }
 
 object ManagerBaseTask {
-  val GENERATION_RATE = 0.1
+  val GENERATION_RATE = com.patson.data.SoloConfig.apGenerationRate
   val INEFFICIENT_CYCLE_THRESHOLD = 8 * 2
-  val MAX_CYCLES_STORED_THRESHOLD = 24 * 4
+  val MAX_CYCLES_STORED_THRESHOLD = com.patson.data.SoloConfig.apMaxCyclesStored
 }
 
 case class AircraftModelManagerTask(startCycle : Int, modelId : Int, modelName : String) extends LevelingManagerTask(startCycle, ManagerTaskType.MANAGER_AIRCRAFT_MODEL) {

--- a/airline-data/src/test/scala/com/patson/data/SoloConfigSpec.scala
+++ b/airline-data/src/test/scala/com/patson/data/SoloConfigSpec.scala
@@ -1,0 +1,20 @@
+package com.patson.data
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+  * With no solo.* keys set, every SoloConfig value must equal the upstream
+  * constant it replaced, so default/multiplayer behavior is unchanged.
+  */
+class SoloConfigSpec extends AnyFlatSpec with Matchers {
+  "SoloConfig" should "default to the original upstream constants" in {
+    SoloConfig.startingBalance shouldBe 0L
+    SoloConfig.minRenewalBalance shouldBe 300000L
+    SoloConfig.apGenerationRate shouldBe 0.1
+    SoloConfig.apMaxCyclesStored shouldBe (24 * 4)
+    SoloConfig.loanDefaultAnnualRate shouldBe 0.11
+    SoloConfig.bankruptcyCashThreshold shouldBe -10000000
+    SoloConfig.bankruptcyAssetsThreshold shouldBe -100000000
+  }
+}

--- a/airline-web/app/controllers/SignUp.scala
+++ b/airline-web/app/controllers/SignUp.scala
@@ -7,7 +7,7 @@ import com.patson.model._
 import com.patson.Authentication
 
 import java.util.Calendar
-import com.patson.data.{AirlineSource, CycleSource, NotificationSource}
+import com.patson.data.{AirlineSource, CycleSource, NotificationSource, SoloConfig}
 import com.patson.model.{Notification, NotificationCategory}
 import com.patson.util.AirlineCache
 import play.api.libs.ws.WSClient
@@ -133,7 +133,8 @@ class SignUp @Inject()(cc: ControllerComponents)(ws: WSClient) extends AbstractC
 
   private def initializeNewAirline(airlineName: String, user: User): Airline = {
     val newAirline = Airline(airlineName)
-    newAirline.setMinimumRenewalBalance(300000)
+    newAirline.setBalance(SoloConfig.startingBalance) //default 0; solo hosts can grant starting capital
+    newAirline.setMinimumRenewalBalance(SoloConfig.minRenewalBalance)
     AirlineSource.saveAirlines(List(newAirline))
     AirlineSource.saveAirlineCode(newAirline.id, newAirline.getDefaultAirlineCode())
     UserSource.setUserAirline(user, newAirline)


### PR DESCRIPTION
Step A of the single-player roadmap (docs plan). Introduces a `SoloConfig` object that makes the punishing early-game constants tunable via a `solo.*` config namespace, **every default equal to the current upstream value** — so this PR changes no behavior on its own; it only unlocks per-host tuning.

Knobs (consumer in parens):
- `solo.startingBalance` / `solo.minRenewalBalance` (SignUp)
- `solo.ap.generationRate` / `solo.ap.maxCyclesStored` (ManagerBaseTask → ManagerSimulation)
- `solo.loan.defaultAnnualRate` (Bank)
- `solo.bankruptcy.cashThreshold` / `solo.bankruptcy.assetsThreshold` (GameConstants → AirlineSimulation)

Reads `Constants.configFactory` (honors `-Dsolo.*` system properties), matching the existing `simulation.pauseWhenIdle` / `mysqldb.*` pattern. A single-player host opts into a friendlier curve via `SBT_OPTS` without forking upstream balance. Documented as commented examples in `application.conf`. Added a DB-free `SoloConfigSpec` asserting defaults equal the old constants.

Recommended solo values (to be wired into the OptiPlex deploy in a follow-up, then playtested): startingBalance 25M, ap.generationRate 0.3, loan rate 0.06, bankruptcy -25M/-150M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)