### PR TITLE
feat(solo): solo-mode toggle to hide multiplayer UI (Step B)

### DIFF
--- a/airline-web/app/views/fragments/modals.scala.html
+++ b/airline-web/app/views/fragments/modals.scala.html
@@ -1926,6 +1926,22 @@
 			  </div>
 			  <div class="table-row h-8">
 				  <div class="cell">
+					  <h5>Solo Mode</h5>
+				  </div>
+				  <div class="cell" style="vertical-align:middle; text-align:center;">
+					  <fieldset>
+						  <div class="switch">
+							  <input type="radio" class="switch-input" name="soloMode" value="off" id="switchSoloOff" onchange="toggleSoloMode()" checked>
+							  <label for="switchSoloOff" class="switch-label switch-label-off">Off</label>
+							  <input type="radio" class="switch-input dark" name="soloMode" value="on" id="switchSoloOn" onchange="toggleSoloMode()">
+							  <label for="switchSoloOn" class="switch-label switch-label-on">On</label>
+							  <span class="switch-selection"></span>
+						  </div>
+					  </fieldset>
+				  </div>
+			  </div>
+			  <div class="table-row h-8">
+				  <div class="cell">
 					  <h5>Default Wallpaper</h5>
 				  </div>
 				  <div class="cell" style="text-align:left;">

--- a/airline-web/public/javascripts/login.js
+++ b/airline-web/public/javascripts/login.js
@@ -181,6 +181,7 @@ async function doPostLoginSetup(user) {
 
     mobileCheck();
     refreshWallpaper();
+    applySoloMode();
 
     // Airline-specific setup
     if (user.airlineIds && user.airlineIds.length > 0) {

--- a/airline-web/public/javascripts/settings.js
+++ b/airline-web/public/javascripts/settings.js
@@ -30,6 +30,21 @@ var wallpaperTemplates = [
 
 ]
 
+function toggleSoloMode() {
+    var solo = $("#switchSoloOn").is(":checked")
+    localStorage.setItem('soloMode', solo)
+    applySoloMode()
+}
+
+// Hide multiplayer surfaces (chat, alliances, rivals, leaderboards) for solo play.
+// Driven by the body.solo-mode CSS rule in main.css.
+function applySoloMode() {
+    var solo = localStorage.getItem('soloMode') === 'true'
+    document.body.classList.toggle('solo-mode', solo)
+    $("#switchSoloOn").prop('checked', solo)
+    $("#switchSoloOff").prop('checked', !solo)
+}
+
 function changeWallpaper() {
     var wallpaperIndex = 0
     if (localStorage.getItem('wallpaperIndex')) {

--- a/airline-web/public/stylesheets/main.css
+++ b/airline-web/public/stylesheets/main.css
@@ -2890,6 +2890,14 @@ i, .italic {
     color: var(--text-color);
 }
 
+/* Solo mode: hide multiplayer-only surfaces (toggled in Style Settings). */
+body.solo-mode [data-link="rivals"],
+body.solo-mode [data-link="alliance"],
+body.solo-mode [data-link="champions"],
+body.solo-mode #live-chat {
+    display: none !important;
+}
+
 #loginPageOverlay .login-form input::placeholder {
     color: var(--placeholder-color);
 }


### PR DESCRIPTION
Step B of the single-player roadmap. Adds a **Solo Mode** switch to Style Settings that hides multiplayer-only surfaces (chat, alliances, rivals, leaderboards) for a cleaner solo experience.

Client-only, mirroring the existing `localStorage` settings pattern:
- `toggleSoloMode()` / `applySoloMode()` in `settings.js`, applied on login (after `refreshWallpaper()`).
- `body.solo-mode` CSS rule in `main.css` hides surfaces via their existing `data-link` hooks (`rivals`, `alliance`, `champions`) + `#live-chat`.
- Switch row in the settings modal (`modals.scala.html`), same markup as Map Projection.

No server/DB change. CI validates the Twirl template compiles; the toggle behavior will be verified live on the OptiPlex after deploy. Full post-login Playwright coverage is deferred (matches the perf roadmap's Phase 6 "login flow" e2e item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)