### PR TITLE
feat(solo): financial notifications (Step C)

### DIFF
--- a/airline-data/src/main/resources/application.conf
+++ b/airline-data/src/main/resources/application.conf
@@ -58,3 +58,8 @@ hikari.connectionTimeout = 90000
 # solo.loan.defaultAnnualRate = 0.06       # default 0.11
 # solo.bankruptcy.cashThreshold = -25000000   # default -10000000
 # solo.bankruptcy.assetsThreshold = -150000000 # default -100000000
+# Financial notifications for player airlines (simulation process):
+# solo.notify.enabled = true               # default false
+# solo.notify.cashWarningThreshold = 5000000   # warn below this balance
+# solo.notify.profitMilestone = 10000000       # praise above this weekly profit
+# solo.notify.intervalCycles = 4           # throttle: emit at most every N cycles

--- a/airline-data/src/main/scala/com/patson/AirlineSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/AirlineSimulation.scala
@@ -191,6 +191,24 @@ object AirlineSimulation {
       val airlineExpense = airlineExpenseNormalized + -loanInterestEntry + linksFuelTax + (actualFuelCost - linksFuelCost) + dividendsPaid
       val airlineProfit = airlineRevenue - airlineExpense
 
+      // Single-player financial notifications (gated; player airlines only).
+      // Throttled to once per interval and replaced in place so the bell isn't
+      // spammed while a condition persists.
+      if (SoloConfig.notifyEnabled && !isBankrupt && airline.airlineType != NonPlayerAirline && cycle % SoloConfig.notifyIntervalCycles == 0) {
+        if (airlineValue.existingBalance < SoloConfig.notifyCashWarningThreshold) {
+          NotificationSource.deleteNotificationsByTargetId(airline.id, "cashflow", NotificationCategory.CASH_FLOW_WARNING)
+          NotificationSource.insertNotification(Notification(airline.id, NotificationCategory.CASH_FLOW_WARNING,
+            s"Low cash: your balance is ${String.format("%,d", airlineValue.existingBalance)}. Consider a loan or trimming unprofitable routes.",
+            cycle, targetId = Some("cashflow"), expiryCycle = Some(cycle + SoloConfig.notifyIntervalCycles)))
+        }
+        if (airlineProfit >= SoloConfig.notifyProfitMilestone) {
+          NotificationSource.deleteNotificationsByTargetId(airline.id, "profit", NotificationCategory.PROFIT_MILESTONE)
+          NotificationSource.insertNotification(Notification(airline.id, NotificationCategory.PROFIT_MILESTONE,
+            s"Strong week: ${String.format("%,d", airlineProfit)} profit. Keep expanding!",
+            cycle, targetId = Some("profit"), expiryCycle = Some(cycle + SoloConfig.notifyIntervalCycles)))
+        }
+      }
+
       // Record weekly ledger entries
       if (!isBankrupt) {
         val weeklyLedger = List(

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -15,6 +15,7 @@ object SoloConfig {
   private def longAt(path : String, default : Long) : Long = if (config.hasPath(path)) config.getLong(path) else default
   private def intAt(path : String, default : Int) : Int = if (config.hasPath(path)) config.getInt(path) else default
   private def doubleAt(path : String, default : Double) : Double = if (config.hasPath(path)) config.getDouble(path) else default
+  private def boolAt(path : String, default : Boolean) : Boolean = if (config.hasPath(path)) config.getBoolean(path) else default
 
   // New-player economy (consumed by airline-web SignUp)
   val startingBalance : Long = longAt("solo.startingBalance", 0L)
@@ -30,4 +31,11 @@ object SoloConfig {
   // Bankruptcy thresholds (GameConstants / AirlineSimulation)
   val bankruptcyCashThreshold : Int = intAt("solo.bankruptcy.cashThreshold", -10_000_000)
   val bankruptcyAssetsThreshold : Int = intAt("solo.bankruptcy.assetsThreshold", -100_000_000)
+
+  // Financial notifications for player airlines (AirlineSimulation). Off by
+  // default so multiplayer deploys are unchanged. Throttled by intervalCycles.
+  val notifyEnabled : Boolean = boolAt("solo.notify.enabled", false)
+  val notifyCashWarningThreshold : Long = longAt("solo.notify.cashWarningThreshold", 5_000_000L)
+  val notifyProfitMilestone : Long = longAt("solo.notify.profitMilestone", 10_000_000L)
+  val notifyIntervalCycles : Int = intAt("solo.notify.intervalCycles", 4)
 }

--- a/airline-data/src/main/scala/com/patson/model/Notification.scala
+++ b/airline-data/src/main/scala/com/patson/model/Notification.scala
@@ -44,6 +44,13 @@ object NotificationCategory extends Enumeration {
    *   Navigation:  /flights/{linkId}
    *   Lifecycle:   managed entirely by LinkSimulation (checkLoadFactor / purgeAlerts);
    *                exempt from the 100-notification retention purge.
+   *
+   * CASH_FLOW_WARNING — Single-player: player airline balance below the configured
+   *   warning threshold (gated by solo.notify.enabled). targetId: "cashflow";
+   *   throttled/replaced per solo.notify.intervalCycles.
+   *
+   * PROFIT_MILESTONE — Single-player: player airline weekly profit crossed the
+   *   configured milestone (gated by solo.notify.enabled). targetId: "profit".
    */
-  val NEGOTIATION_LOSS, LEVEL_UP, LOYALIST, GAME_OVER, OLYMPICS_PRIZE, TUTORIAL, LINK_CANCELLATION = Value
+  val NEGOTIATION_LOSS, LEVEL_UP, LOYALIST, GAME_OVER, OLYMPICS_PRIZE, TUTORIAL, LINK_CANCELLATION, CASH_FLOW_WARNING, PROFIT_MILESTONE = Value
 }

--- a/airline-web/public/javascripts/notification.js
+++ b/airline-web/public/javascripts/notification.js
@@ -150,7 +150,9 @@ function getCategoryIcon(category) {
         case 'OLYMPICS_PRIZE': return '🏅'
         case 'TUTORIAL': return '→'
         case 'NEGOTIATION_LOSS':
+        case 'CASH_FLOW_WARNING':
         case 'LINK_CANCELLATION': return '⚠'
+        case 'PROFIT_MILESTONE': return '$'
         default: return '•'
     }
 }


### PR DESCRIPTION
Step C of the single-player roadmap. Player airlines get pushed financial feedback so the wait between cycles has purpose. **Gated behind `solo.notify.enabled` (default false)** — multiplayer/default deploys are unchanged.

- `CASH_FLOW_WARNING` when balance < `solo.notify.cashWarningThreshold`
- `PROFIT_MILESTONE` when weekly profit ≥ `solo.notify.profitMilestone`

Emitted from `AirlineSimulation` for non-NPC airlines only (`airlineType != NonPlayerAirline`), at the point where balance and weekly profit are both in scope. Throttled to once per `solo.notify.intervalCycles` and replaced in place via `deleteNotificationsByTargetId` (targetId `cashflow`/`profit`) so the bell is not spammed while a condition persists. Adds the two enum values (append-only) and `notification.js` icons (⚠ / $).

Verify live: set `-Dsolo.notify.enabled=true` + a high `cashWarningThreshold` on the sim process, fast-forward a cycle, confirm a `CASH_FLOW_WARNING` row in the `notification` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)