### PR TITLE
perf(sim): passenger consume loop early-exit (Step D)

### DIFF
--- a/airline-data/src/main/scala/com/patson/PassengerSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/PassengerSimulation.scala
@@ -95,7 +95,11 @@ object PassengerSimulation {
 
     val externalCostModifier = ExternalCostModifier(airlineCostModifiers, specializationCostModifiers)
 
-    while (consumptionCycleCount <= consumptionCycleMax) {
+    // Once demandChunks is exhausted, every remaining iteration just re-partitions
+    // an empty list into empty results (a no-op), so exit early. missedDemandChunks
+    // is tracked separately and never re-enters demandChunks, so this is behavior-
+    // preserving — it only skips wasted passes when there is nothing left to place.
+    while (consumptionCycleCount <= consumptionCycleMax && demandChunks.nonEmpty) {
       println(s"Run loop $consumptionCycleCount for ${demandChunks.size} demand chunks")
 
       //using minSeats to have pax book together and decrease consumptions


### PR DESCRIPTION
Step D of the single-player roadmap (perf). The passenger consume loop always ran all 10 iterations even after every demand chunk was placed or missed. Once `demandChunks` is empty, each further iteration only re-partitions an empty list into empty results — a no-op.

Change: add `demandChunks.nonEmpty` to the `while` condition. `missedDemandChunks` is tracked separately and never re-enters `demandChunks`, so transported-pax totals are identical; this only skips wasted passes when there is nothing left to place. On a sparse early-game world (where demand exhausts before iteration 10) this trims real time off the heaviest phase; on a saturated world it is a no-op.

Verify live: compare the existing `link=…ms` phase timing and the `Total transported pax` log line over ~5 cycles before/after — pax must match within noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)