### PR TITLE
chore(deploy): enable recommended solo economy values

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -25,8 +25,26 @@ jobs:
 
       - name: Deploy stack
         env:
-          # Full-dataset cycles need more than the start script's 1.5G default.
-          SIM_EXTRA_OPTS: -Xmx2048M
+          # -Xmx2048M: full-dataset cycles need more than the start script's 1.5G.
+          # solo.*: friendlier single-player economy + financial notifications
+          # (see com.patson.data.SoloConfig). Tune these freely — they only
+          # affect this self-hosted instance.
+          SIM_EXTRA_OPTS: >-
+            -Xmx2048M
+            -Dsolo.ap.generationRate=0.3
+            -Dsolo.loan.defaultAnnualRate=0.06
+            -Dsolo.bankruptcy.cashThreshold=-25000000
+            -Dsolo.bankruptcy.assetsThreshold=-150000000
+            -Dsolo.notify.enabled=true
+          # Web process (sign-up + tooltips): starting capital and the same
+          # economy display values so tooltips match the simulation.
+          WEB_SOLO_OPTS: >-
+            -Dsolo.startingBalance=25000000
+            -Dsolo.minRenewalBalance=100000
+            -Dsolo.ap.generationRate=0.3
+            -Dsolo.loan.defaultAnnualRate=0.06
+            -Dsolo.bankruptcy.cashThreshold=-25000000
+            -Dsolo.bankruptcy.assetsThreshold=-150000000
         run: bash scripts/optiplex-deploy.sh
 
       - name: Install e2e dependencies

--- a/scripts/optiplex-deploy.sh
+++ b/scripts/optiplex-deploy.sh
@@ -80,7 +80,7 @@ fi
 echo "==> Starting simulation (SIM_EXTRA_OPTS='$SIM_EXTRA_OPTS') and web"
 docker exec -d -e SIM_EXTRA_OPTS="$SIM_EXTRA_OPTS" airline-app \
   sh -c 'sh /home/airline/start-data.sh > /home/airline/sim.log 2>&1'
-docker exec -d -e WEB_EXTRA_OPTS="$DB_OVERRIDE" airline-app \
+docker exec -d -e WEB_EXTRA_OPTS="$DB_OVERRIDE ${WEB_SOLO_OPTS:-}" airline-app \
   sh -c 'sh /home/airline/start-web.sh > /home/airline/web.log 2>&1'
 
 echo "==> Waiting for HTTP 200 from :9000 (up to 10 min)"


### PR DESCRIPTION
Wires the `SoloConfig` knobs into the OptiPlex deploy so Steps A & C actually take effect on this self-hosted instance (they shipped with upstream-identical defaults):

- **sim process** (`SIM_EXTRA_OPTS`): `solo.ap.generationRate=0.3`, `solo.loan.defaultAnnualRate=0.06`, `solo.bankruptcy.cashThreshold=-25000000`, `solo.bankruptcy.assetsThreshold=-150000000`, `solo.notify.enabled=true` (plus the existing `-Xmx2048M`).
- **web process** (new `WEB_SOLO_OPTS` passthrough): `solo.startingBalance=25000000`, `solo.minRenewalBalance=100000`, and the same economy values so tooltips match.

Only affects this instance; upstream balance untouched. Values are easily tuned by editing this env. `startingBalance` applies to airlines created after deploy; the rest apply every cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)