### PR TITLE
perf(sim): demand timing split for E decision (measure-first)

### DIFF
--- a/airline-data/src/main/scala/com/patson/DemandGenerator.scala
+++ b/airline-data/src/main/scala/com/patson/DemandGenerator.scala
@@ -1,6 +1,6 @@
 package com.patson
 
-import com.patson.data.{AirportSource, CountrySource, CycleSource, DestinationSource, EventSource, GameConstants}
+import com.patson.data.{AirportSource, CountrySource, CycleSource, DestinationSource, EventSource, GameConstants, SoloConfig}
 import com.patson.model.event.{EventType, Olympics}
 import com.patson.model.{PassengerType, _}
 import com.patson.util.AirportCache
@@ -181,6 +181,14 @@ object DemandGenerator {
     val countryRelationships = CountrySource.getCountryMutualRelationships()
     val destinationList = DestinationSource.loadAllEliteDestinations()
 
+    // Diagnostic (solo.demand.profile): measure base-demand vs chunk-generation
+    // cost to decide if memoizing the base layer is worthwhile. Zero overhead off.
+    val profileDemand = SoloConfig.demandProfile
+    val baseDemandNanos = new java.util.concurrent.atomic.AtomicLong(0)
+    val chunkGenNanos = new java.util.concurrent.atomic.AtomicLong(0)
+    def timedProfile[T](acc : java.util.concurrent.atomic.AtomicLong)(block : => T) : T =
+      if (profileDemand) { val t0 = System.nanoTime(); try block finally acc.addAndGet(System.nanoTime() - t0) } else block
+
     val computedDemandChunks = airports.par.flatMap { fromAirport =>
       val flightPreferencesPool = getFlightPreferencePoolOnAirport(fromAirport)
       val hubAirportsDemands = generateHubAirportDemand(fromAirport, cycle)
@@ -192,14 +200,14 @@ object DemandGenerator {
           val relationship = countryRelationships.getOrElse((fromAirport.countryCode, toAirport.countryCode), 0)
           val affinity = Computation.calculateAffinityValue(fromAirport.zone, toAirport.zone, relationship)
           
-          val demand = computeBaseDemandBetweenAirports(fromAirport, toAirport, affinity, distance)
+          val demand = timedProfile(baseDemandNanos)(computeBaseDemandBetweenAirports(fromAirport, toAirport, affinity, distance))
 
           // Combine all chunks for this airport pair
           val travelerDemandValue = demand.travelerDemand + hubAirportsDemands.getOrElse(toAirport.iata, LinkClassValues.empty)
           val travelerType = if (fromAirport.population > PassengerType.TRAVELER_SMALL_TOWN_CEILING) PassengerType.TRAVELER else PassengerType.TRAVELER_SMALL_TOWN
-          val travelerChunks = generateChunksForPassengerType(travelerDemandValue, fromAirport, toAirport, travelerType, flightPreferencesPool, airportStats, cycle, cyclePhaseLength)
-          val businessChunks = generateChunksForPassengerType(demand.businessDemand, fromAirport, toAirport, PassengerType.BUSINESS, flightPreferencesPool, airportStats, cycle, cyclePhaseLength)
-          val touristChunks = generateChunksForPassengerType(demand.touristDemand, fromAirport, toAirport, PassengerType.TOURIST, flightPreferencesPool, airportStats, cycle, cyclePhaseLength)
+          val travelerChunks = timedProfile(chunkGenNanos)(generateChunksForPassengerType(travelerDemandValue, fromAirport, toAirport, travelerType, flightPreferencesPool, airportStats, cycle, cyclePhaseLength))
+          val businessChunks = timedProfile(chunkGenNanos)(generateChunksForPassengerType(demand.businessDemand, fromAirport, toAirport, PassengerType.BUSINESS, flightPreferencesPool, airportStats, cycle, cyclePhaseLength))
+          val touristChunks = timedProfile(chunkGenNanos)(generateChunksForPassengerType(demand.touristDemand, fromAirport, toAirport, PassengerType.TOURIST, flightPreferencesPool, airportStats, cycle, cyclePhaseLength))
 
           travelerChunks ++ businessChunks ++ touristChunks
         } else {
@@ -218,6 +226,9 @@ object DemandGenerator {
     }.toList // .toList converts the parallel collection back to a standard List
 
     println(s"Generated ${computedDemandChunks.length} demand chunks from regular/elite demand")
+    if (profileDemand) {
+      println(s"[demand-profile] base-demand total ${baseDemandNanos.get / 1000000}ms vs chunk-generation total ${chunkGenNanos.get / 1000000}ms (regular demand, summed across threads)")
+    }
 
     // Event Demand (can be handled separately as it's smaller) ---
     val eventDemand = generateEventDemand(cycle, airports)

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -38,4 +38,8 @@ object SoloConfig {
   val notifyCashWarningThreshold : Long = longAt("solo.notify.cashWarningThreshold", 5_000_000L)
   val notifyProfitMilestone : Long = longAt("solo.notify.profitMilestone", 10_000_000L)
   val notifyIntervalCycles : Int = intAt("solo.notify.intervalCycles", 4)
+
+  // Diagnostic: split DemandGenerator timing into base-demand vs chunk-generation
+  // to decide whether memoizing the base layer is worthwhile (off by default).
+  val demandProfile : Boolean = boolAt("solo.demand.profile", false)
 }


### PR DESCRIPTION
Step E, measure-first (per your choice). Adds `solo.demand.profile` (default false) that times `computeBaseDemandBetweenAirports` vs `generateChunksForPassengerType` separately and logs the split (`[demand-profile] base-demand total Xms vs chunk-generation total Yms`).

This decides whether memoizing the base demand layer is worth the correctness risk before building the cache. If base-demand is a small fraction of the per-pair cost (likely — the randomizer chunk layer runs 3× per pair every cycle), we skip the memoization. Zero overhead when the flag is off.

Plan: merge, enable `-Dsolo.demand.profile=true` for one cycle on the OptiPlex, read the split, decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)