### PR TITLE
feat(solo): living-world dynamic AI MVP, drop-only (Step F)

### DIFF
--- a/airline-data/src/main/scala/com/patson/ComputerAirlineSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/ComputerAirlineSimulation.scala
@@ -1,0 +1,55 @@
+package com.patson
+
+import com.patson.data.{AirlineSource, LinkSource, SoloConfig}
+import com.patson.model.NonPlayerAirline
+
+/**
+  * Living-world dynamic AI (single-player). A cheap per-cycle phase that lets
+  * computer-controlled (NonPlayerAirline) carriers react instead of sitting
+  * static. MVP scope is deliberately drop-only: each acting NPC cancels its
+  * worst persistently money-losing route. This is self-limiting (it can only
+  * remove links, never add cost or explode the network) and bounded to a
+  * rotating subset of NPCs per cycle, so it cannot destabilize the economy or
+  * blow the cycle budget. Gated behind solo.ai.enabled (default off).
+  *
+  * Player airlines are never touched — only NonPlayerAirline carriers are loaded.
+  */
+object ComputerAirlineSimulation {
+  def simulate(cycle : Int) : Unit = {
+    if (!SoloConfig.aiEnabled) return
+
+    try {
+      val npcAirlines = AirlineSource.loadAirlinesByCriteria(List(("airline_type", NonPlayerAirline.id)))
+      if (npcAirlines.isEmpty) return
+
+      // Act on a rotating, bounded subset each cycle to keep the cost small.
+      val perCycle = Math.max(1, SoloConfig.aiAirlinesPerCycle)
+      val sorted = npcAirlines.sortBy(_.id)
+      val offset = ((cycle.toLong * perCycle) % sorted.size).toInt
+      val acting = (0 until Math.min(perCycle, sorted.size)).map(i => sorted((offset + i) % sorted.size))
+
+      var totalDrops = 0
+      acting.foreach { airline =>
+        try {
+          // Sum recent profit per link over the lookback window; drop the worst
+          // links whose cumulative profit is below the (negative) threshold.
+          val consumptions = LinkSource.loadLinkConsumptionsByAirline(airline.id, SoloConfig.aiLossLookbackCycles)
+          if (consumptions.nonEmpty) {
+            val profitByLink = consumptions.groupBy(_.link.id).map { case (linkId, list) => (linkId, list.map(_.profit.toLong).sum) }
+            val losers = profitByLink.filter(_._2 < SoloConfig.aiDropProfitThreshold).toList.sortBy(_._2)
+            losers.take(Math.max(0, SoloConfig.aiMaxDropsPerAirline)).foreach { case (linkId, totalProfit) =>
+              LinkSource.deleteLink(linkId)
+              totalDrops += 1
+              println(s"[ai] ${airline.name} dropped losing link $linkId (profit $totalProfit over ${SoloConfig.aiLossLookbackCycles} cycles)")
+            }
+          }
+        } catch {
+          case e : Exception => println(s"[ai] error processing airline ${airline.id}: ${e.getMessage}")
+        }
+      }
+      println(s"[ai] cycle $cycle: ${acting.size} NPC airline(s) acted, $totalDrops link(s) dropped")
+    } catch {
+      case e : Exception => println(s"[ai] ComputerAirlineSimulation failed (skipping): ${e.getClass.getSimpleName}: ${e.getMessage}")
+    }
+  }
+}

--- a/airline-data/src/main/scala/com/patson/MainSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/MainSimulation.scala
@@ -162,6 +162,14 @@ object MainSimulation extends App {
     }
     println("Airplane model simulation done")
 
+    // Living-world AI (single-player, gated by solo.ai.enabled). Runs after the
+    // economic sims so this cycle's link profit data is fresh.
+    println("Computer airline simulation")
+    timed("computerAirline") {
+      ComputerAirlineSimulation.simulate(cycle)
+    }
+    println("Computer airline simulation done")
+
     timed("purge") {
       //purge history
       println("Purging link history")

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -42,4 +42,13 @@ object SoloConfig {
   // Diagnostic: split DemandGenerator timing into base-demand vs chunk-generation
   // to decide whether memoizing the base layer is worthwhile (off by default).
   val demandProfile : Boolean = boolAt("solo.demand.profile", false)
+
+  // Living-world dynamic AI (ComputerAirlineSimulation). Off by default. MVP is
+  // drop-only: NPC airlines cancel persistently money-losing routes. Bounded per
+  // cycle so it cannot destabilize the economy or blow the cycle budget.
+  val aiEnabled : Boolean = boolAt("solo.ai.enabled", false)
+  val aiAirlinesPerCycle : Int = intAt("solo.ai.airlinesPerCycle", 10)
+  val aiMaxDropsPerAirline : Int = intAt("solo.ai.maxDropsPerAirline", 1)
+  val aiLossLookbackCycles : Int = intAt("solo.ai.lossLookbackCycles", 4)
+  val aiDropProfitThreshold : Long = longAt("solo.ai.dropProfitThreshold", -500000L)
 }


### PR DESCRIPTION
Step F of the single-player roadmap — the living-world change. New `ComputerAirlineSimulation` runs as a cheap per-cycle phase (after the economic sims, before purge, so this cycle''s link profit is fresh) so NPC airlines react instead of sitting static.

**MVP scope: drop-only** (your choice). Each acting NPC cancels its worst persistently money-losing route:
- Loads only `NonPlayerAirline` carriers — player airlines are never touched.
- Acts on a rotating, bounded subset per cycle (`solo.ai.airlinesPerCycle`, default 10).
- Sums each link''s profit over `solo.ai.lossLookbackCycles` (default 4); drops up to `solo.ai.maxDropsPerAirline` (default 1) links below `solo.ai.dropProfitThreshold` (default -500k).
- Self-limiting (can only remove links), wrapped in try/catch so an AI bug can never abort the cycle.

Gated behind `solo.ai.enabled` (default **false**) — zero effect until enabled. The `computerAirline=…ms` phase timing lets us watch its cost.

Verify live: enable `-Dsolo.ai.enabled=true`, fast-forward cycles, tail sim.log for `[ai]` drop lines and `computerAirline=…ms`, confirm NPC link counts drift down sensibly and player airlines are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)