### PR TITLE
chore(deploy): enable drop-only AI + one-shot demand profiling

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -36,6 +36,8 @@ jobs:
             -Dsolo.bankruptcy.cashThreshold=-25000000
             -Dsolo.bankruptcy.assetsThreshold=-150000000
             -Dsolo.notify.enabled=true
+            -Dsolo.ai.enabled=true
+            -Dsolo.demand.profile=true
           # Web process (sign-up + tooltips): starting capital and the same
           # economy display values so tooltips match the simulation.
           WEB_SOLO_OPTS: >-


### PR DESCRIPTION
Enables solo.ai.enabled (drop-only living-world AI) on the OptiPlex and adds solo.demand.profile for a single measurement cycle (removed in a follow-up). Lets us observe [ai] drop behavior + computerAirline timing and the demand base-vs-chunk split on one clean process-managed sim.