### PR TITLE
chore(deploy): remove one-shot demand profiling, keep AI on

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -37,7 +37,6 @@ jobs:
             -Dsolo.bankruptcy.assetsThreshold=-150000000
             -Dsolo.notify.enabled=true
             -Dsolo.ai.enabled=true
-            -Dsolo.demand.profile=true
           # Web process (sign-up + tooltips): starting capital and the same
           # economy display values so tooltips match the simulation.
           WEB_SOLO_OPTS: >-


### PR DESCRIPTION
Measurement complete (base-demand ~55x chunk-generation, so Step E memoization is worth building). Removes the profiling flag (per-pair nanoTime overhead); keeps solo.ai.enabled (drop-only AI confirmed safe: 6-7 bounded NPC link drops/cycle).