### PR TITLE
perf(demand): instrument base-demand cache size (Step E-0)

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -37,6 +37,7 @@ jobs:
             -Dsolo.bankruptcy.assetsThreshold=-150000000
             -Dsolo.notify.enabled=true
             -Dsolo.ai.enabled=true
+            -Dsolo.demand.profile=true
           # Web process (sign-up + tooltips): starting capital and the same
           # economy display values so tooltips match the simulation.
           WEB_SOLO_OPTS: >-

--- a/airline-data/src/main/scala/com/patson/DemandGenerator.scala
+++ b/airline-data/src/main/scala/com/patson/DemandGenerator.scala
@@ -186,6 +186,9 @@ object DemandGenerator {
     val profileDemand = SoloConfig.demandProfile
     val baseDemandNanos = new java.util.concurrent.atomic.AtomicLong(0)
     val chunkGenNanos = new java.util.concurrent.atomic.AtomicLong(0)
+    // Step E-0: count the pairs a base-demand cache would hold so we can size it
+    // against the sim heap before committing to memoization (solo.demand.memoize).
+    val validPairCount = new java.util.concurrent.atomic.AtomicLong(0)
     def timedProfile[T](acc : java.util.concurrent.atomic.AtomicLong)(block : => T) : T =
       if (profileDemand) { val t0 = System.nanoTime(); try block finally acc.addAndGet(System.nanoTime() - t0) } else block
 
@@ -197,6 +200,7 @@ object DemandGenerator {
       val regularDemandChunks = airports.flatMap { toAirport =>
         val distance = Computation.calculateDistance(fromAirport, toAirport)
         if (canHaveDemand(fromAirport, toAirport, distance)) {
+          if (profileDemand) validPairCount.incrementAndGet()
           val relationship = countryRelationships.getOrElse((fromAirport.countryCode, toAirport.countryCode), 0)
           val affinity = Computation.calculateAffinityValue(fromAirport.zone, toAirport.zone, relationship)
           
@@ -228,6 +232,11 @@ object DemandGenerator {
     println(s"Generated ${computedDemandChunks.length} demand chunks from regular/elite demand")
     if (profileDemand) {
       println(s"[demand-profile] base-demand total ${baseDemandNanos.get / 1000000}ms vs chunk-generation total ${chunkGenNanos.get / 1000000}ms (regular demand, summed across threads)")
+      // Step E-0: cache-sizing. A base-demand entry is a Demand (3 x LinkClassValues =
+      // 12 ints ~48B) plus per-entry map overhead; ~64B/entry is a conservative estimate.
+      val pairs = validPairCount.get
+      val estBytes = pairs * 64
+      println(s"[demand-cache-size] airports=${airports.size} validPairs=$pairs estCacheBytes=$estBytes (~${estBytes / 1024 / 1024}MB at ~64B/entry)")
     }
 
     // Event Demand (can be handled separately as it's smaller) ---


### PR DESCRIPTION
## Step E-0 — size the demand base-layer cache before building it

The `solo.demand.profile` measurement (cycles 9/10) showed **base-demand compute ≈ 55× the chunk-generation cost** — so memoizing the deterministic base layer (`computeBaseDemandBetweenAirports`) is the remaining ~20% wall-clock win.

Before committing to an in-heap cache, we need to **size it against the 2 GB sim heap**. The regular-demand loop is `airports × airports`; `canHaveDemand` only drops distance ≤ 175 pairs, so the cache approaches N² `Demand` entries. At N≈3–4k that's ~9–16M entries (~1–1.8 GB) — a naïve cache could OOM, and the sim runs with **no process manager**, so an OOM is especially costly.

This PR adds a one-shot log, **gated by the existing `solo.demand.profile` flag** (zero overhead when off), reporting:
- `airports` — N after the `iata != "" && popMiddleIncome > 0` filter
- `validPairs` — pairs passing `canHaveDemand` (counted inside the existing loop, no extra O(N²) pass)
- `estCacheBytes` — at ~64 B/entry

Decision gate from the result (see plan): <700 MB → full cache; 700 MB–1.2 GB → cache + heap bump / scope to top airports; >1.2 GB → fall back to CPU-hoist only.

No behavior change with the flag off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)