### PR TITLE
ci: print Step E-0 measurement to stdout

### DIFF
--- a/.github/workflows/read-sim-measurement.yml
+++ b/.github/workflows/read-sim-measurement.yml
@@ -19,11 +19,18 @@ jobs:
     steps:
       - name: Tail demand measurement lines from sim.log
         run: |
+          # Print to stdout (captured headlessly by `gh run view --log`) AND to the
+          # job summary. The MEASUREMENT markers make the lines easy to extract.
+          echo "=== MEASUREMENT-BEGIN ==="
+          docker exec airline-app sh -c \
+            'grep -aE "demand-cache-size|demand-profile|Loaded .* airports" /home/airline/sim.log | tail -20' \
+            || echo "no matching lines yet (cycle may not have reached demand generation)"
+          echo "=== MEASUREMENT-END ==="
           {
             echo "## Demand measurement (latest matches in sim.log)"
             echo '```'
             docker exec airline-app sh -c \
               'grep -aE "demand-cache-size|demand-profile|Loaded .* airports" /home/airline/sim.log | tail -20' \
-              || echo "no matching lines yet (cycle may not have reached demand generation)"
+              || echo "no matching lines yet"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Makes the read-sim-measurement helper echo the grep result to stdout (between MEASUREMENT-BEGIN/END markers) so the numbers can be captured headlessly via `gh run view --log`, in addition to the job summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)