### PR TITLE
ci: add heap/memory readout to sim measurement

### DIFF
--- a/.github/workflows/read-sim-measurement.yml
+++ b/.github/workflows/read-sim-measurement.yml
@@ -26,6 +26,14 @@ jobs:
             'grep -aE "demand-cache-size|demand-profile|Loaded .* airports" /home/airline/sim.log | tail -20' \
             || echo "no matching lines yet (cycle may not have reached demand generation)"
           echo "=== MEASUREMENT-END ==="
+          # Step E-1 sizing: container memory headroom under the 2GB sim heap, to
+          # decide if a permanent ~635MB dense base-demand cache fits without OOM.
+          echo "=== HEAP-BEGIN ==="
+          docker stats --no-stream airline-app || echo "no docker stats"
+          docker exec airline-app sh -c \
+            'jcmd $(pgrep -f MainSimulation | head -1) GC.heap_info 2>/dev/null' \
+            || echo "no jcmd heap info"
+          echo "=== HEAP-END ==="
           {
             echo "## Demand measurement (latest matches in sim.log)"
             echo '```'

--- a/.github/workflows/read-sim-measurement.yml
+++ b/.github/workflows/read-sim-measurement.yml
@@ -19,11 +19,18 @@ jobs:
     steps:
       - name: Tail demand measurement lines from sim.log
         run: |
+          # Print to stdout (captured headlessly by `gh run view --log`) AND to the
+          # job summary. The MEASUREMENT markers make the lines easy to extract.
+          echo "=== MEASUREMENT-BEGIN ==="
+          docker exec airline-app sh -c \
+            'grep -aE "demand-cache-size|demand-profile|Loaded .* airports" /home/airline/sim.log | tail -20' \
+            || echo "no matching lines yet (cycle may not have reached demand generation)"
+          echo "=== MEASUREMENT-END ==="
           {
             echo "## Demand measurement (latest matches in sim.log)"
             echo '```'
             docker exec airline-app sh -c \
               'grep -aE "demand-cache-size|demand-profile|Loaded .* airports" /home/airline/sim.log | tail -20' \
-              || echo "no matching lines yet (cycle may not have reached demand generation)"
+              || echo "no matching lines yet"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds `docker stats` + JVM `GC.heap_info` to the Read Sim Measurement helper so Step E-1 can size the base-demand cache against real heap headroom. The N²-pair object cache from the original plan is ~3GB (LinkClassValues carry stored `total`/`totalwithSeatSize` fields → ~230B/entry × 13.2M) and would OOM the unmanaged 2GB sim; a dense primitive int matrix is ~635MB. This readout decides whether even that fits, or whether E falls back to the zero-memory CPU hoist.

Reader-only, does not restart the sim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)