### PR TITLE
perf(demand): memoize base-demand layer across cycles (Step E-1)

### DIFF
--- a/airline-data/src/main/scala/com/patson/DemandGenerator.scala
+++ b/airline-data/src/main/scala/com/patson/DemandGenerator.scala
@@ -192,6 +192,22 @@ object DemandGenerator {
     def timedProfile[T](acc : java.util.concurrent.atomic.AtomicLong)(block : => T) : T =
       if (profileDemand) { val t0 = System.nanoTime(); try block finally acc.addAndGet(System.nanoTime() - t0) } else block
 
+    // Step E-1: memoize the deterministic base-demand layer across cycles. Build a
+    // primitive id->row-index map for this cycle and run single-threaded eviction
+    // before the parallel loop; the cache itself is read/written lock-free inside it.
+    val memoize = SoloConfig.demandMemoize
+    val idToIndex: Array[Int] =
+      if (memoize) {
+        val orderedAirports = airports.toArray
+        val maxId = orderedAirports.foldLeft(0)((m, a) => if (a.id > m) a.id else m)
+        val idx = Array.fill(maxId + 1)(-1)
+        var i = 0
+        while (i < orderedAirports.length) { idx(orderedAirports(i).id) = i; i += 1 }
+        val (fullReset, changedCount) = prepareBaseDemandCache(orderedAirports, countryRelationships.hashCode.toLong)
+        println(s"[demand-memoize] ${if (fullReset) "full-reset" else s"incremental evicted=$changedCount"} (N=${orderedAirports.length})")
+        idx
+      } else null
+
     val computedDemandChunks = airports.par.flatMap { fromAirport =>
       val flightPreferencesPool = getFlightPreferencePoolOnAirport(fromAirport)
       val hubAirportsDemands = generateHubAirportDemand(fromAirport, cycle)
@@ -203,8 +219,35 @@ object DemandGenerator {
           if (profileDemand) validPairCount.incrementAndGet()
           val relationship = countryRelationships.getOrElse((fromAirport.countryCode, toAirport.countryCode), 0)
           val affinity = Computation.calculateAffinityValue(fromAirport.zone, toAirport.zone, relationship)
-          
-          val demand = timedProfile(baseDemandNanos)(computeBaseDemandBetweenAirports(fromAirport, toAirport, affinity, distance))
+
+          val demand =
+            if (memoize) {
+              val row = cacheData(idToIndex(fromAirport.id))
+              val base = idToIndex(toAirport.id) * DEMAND_SLOTS
+              if (row(base) == ABSENT) { // miss: compute once, store all 12 slots
+                val d = computeBaseDemandBetweenAirports(fromAirport, toAirport, affinity, distance)
+                row(base)      = d.travelerDemand.economyVal
+                row(base + 1)  = d.travelerDemand.businessVal
+                row(base + 2)  = d.travelerDemand.firstVal
+                row(base + 3)  = d.travelerDemand.discountVal
+                row(base + 4)  = d.businessDemand.economyVal
+                row(base + 5)  = d.businessDemand.businessVal
+                row(base + 6)  = d.businessDemand.firstVal
+                row(base + 7)  = d.businessDemand.discountVal
+                row(base + 8)  = d.touristDemand.economyVal
+                row(base + 9)  = d.touristDemand.businessVal
+                row(base + 10) = d.touristDemand.firstVal
+                row(base + 11) = d.touristDemand.discountVal
+                d
+              } else { // hit: rebuild Demand from the cached ints
+                Demand(
+                  LinkClassValues(row(base),     row(base + 1), row(base + 2),  row(base + 3)),
+                  LinkClassValues(row(base + 4), row(base + 5), row(base + 6),  row(base + 7)),
+                  LinkClassValues(row(base + 8), row(base + 9), row(base + 10), row(base + 11)))
+              }
+            } else {
+              timedProfile(baseDemandNanos)(computeBaseDemandBetweenAirports(fromAirport, toAirport, affinity, distance))
+            }
 
           // Combine all chunks for this airport pair
           val travelerDemandValue = demand.travelerDemand + hubAirportsDemands.getOrElse(toAirport.iata, LinkClassValues.empty)
@@ -695,5 +738,93 @@ object DemandGenerator {
   sealed case class Demand(travelerDemand: LinkClassValues, businessDemand: LinkClassValues, touristDemand: LinkClassValues)
   def addUpDemands(demand: Demand): Int = {
     (demand.travelerDemand.totalwithSeatSize + demand.businessDemand.totalwithSeatSize + demand.touristDemand.totalwithSeatSize).toInt
+  }
+
+  // --- Step E-1: base-demand memoization (solo.demand.memoize) ----------------
+  // computeBaseDemandBetweenAirports is deterministic and costs ~55x the randomized
+  // chunk layer per cycle, but its inputs (airport demographics + country
+  // relationships) barely change cycle-to-cycle. We cache the full Demand result per
+  // ordered airport pair as a dense primitive int matrix (DEMAND_SLOTS ints/pair: 3
+  // LinkClassValues x economy/business/first/discount). Keying by the airport's
+  // index in the loaded list keeps it a flat int[] (no boxing, ~635MB at N=3638)
+  // instead of ~3GB of Demand/HashMap objects.
+  //
+  // Concurrency: each fromAirport owns exactly one outer row, written only by the
+  // single airports.par thread handling it -> lock-free. All eviction is
+  // single-threaded in prepareBaseDemandCache, before the parallel loop.
+  private val DEMAND_SLOTS = 12
+  private val ABSENT = -1                                    // sentinel: slot 0 (traveler economy) is always >= 0 once computed
+  private var cacheData: Array[Array[Int]] = null           // [fromIdx] -> flat [toIdx*DEMAND_SLOTS .. +DEMAND_SLOTS]
+  private var cacheMembershipSig: Long = Long.MinValue       // hash of ordered airport ids; change => full reset
+  private var cacheRelationshipEpoch: Long = Long.MinValue   // hash of country relationships; change => full reset
+  private val cacheFingerprint = new java.util.HashMap[Int, Long]() // airportId -> demographic fingerprint
+
+  // Every field computeBaseDemandBetweenAirports / computeRawDemandBetweenAirports
+  // reads off an airport. affinity (zones + relationship) and distance (lat/long,
+  // static) are covered by zone + the relationship epoch, so they need not be here.
+  private[patson] def airportFingerprint(a: Airport): Long = {
+    var h = 1125899906842597L
+    h = 31 * h + a.income
+    h = 31 * h + a.population
+    h = 31 * h + a.popMiddleIncome
+    h = 31 * h + a.size
+    h = 31 * h + a.zone.hashCode
+    h = 31 * h + a.countryCode.hashCode
+    var fh = 0L // order-independent fold of feature (type, strength)
+    a.getFeatures().foreach { f => fh += (f.featureType.id.toLong << 20) ^ f.strength }
+    31 * h + fh
+  }
+
+  /** Single-threaded cache maintenance, run before the parallel demand loop. Evicts
+    * rows + columns for airports whose demographics changed; full-resets on a change
+    * to airport membership/order or country relationships. Returns (fullReset,
+    * changedAirportCount) for logging. */
+  private[patson] def prepareBaseDemandCache(orderedAirports: Array[Airport], relationshipEpoch: Long): (Boolean, Int) = {
+    val n = orderedAirports.length
+    var membershipSig = 1125899906842597L
+    var i = 0
+    while (i < n) { membershipSig = 31 * membershipSig + orderedAirports(i).id; i += 1 }
+
+    val fullReset = cacheData == null || cacheData.length != n ||
+      membershipSig != cacheMembershipSig || relationshipEpoch != cacheRelationshipEpoch
+
+    if (fullReset) {
+      cacheData = Array.ofDim[Array[Int]](n)
+      i = 0
+      while (i < n) {
+        val row = new Array[Int](n * DEMAND_SLOTS)
+        java.util.Arrays.fill(row, ABSENT)
+        cacheData(i) = row
+        i += 1
+      }
+      cacheFingerprint.clear()
+      i = 0
+      while (i < n) { val a = orderedAirports(i); cacheFingerprint.put(a.id, airportFingerprint(a)); i += 1 }
+      cacheMembershipSig = membershipSig
+      cacheRelationshipEpoch = relationshipEpoch
+      (true, n)
+    } else {
+      val changed = new java.util.ArrayList[Int]()
+      i = 0
+      while (i < n) {
+        val a = orderedAirports(i)
+        val fp = airportFingerprint(a)
+        val prev = cacheFingerprint.get(a.id)
+        if (prev == null || prev.longValue() != fp) {
+          changed.add(i)
+          cacheFingerprint.put(a.id, fp)
+        }
+        i += 1
+      }
+      val it = changed.iterator()
+      while (it.hasNext) {
+        val idx = it.next()
+        java.util.Arrays.fill(cacheData(idx), ABSENT)        // evict the changed airport's row
+        val base = idx * DEMAND_SLOTS
+        var r = 0
+        while (r < n) { cacheData(r)(base) = ABSENT; r += 1 } // and its column in every row
+      }
+      (false, changed.size)
+    }
   }
 }

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -43,6 +43,13 @@ object SoloConfig {
   // to decide whether memoizing the base layer is worthwhile (off by default).
   val demandProfile : Boolean = boolAt("solo.demand.profile", false)
 
+  // Memoize the deterministic base-demand layer across cycles (Step E-1). The base
+  // layer is ~55x the per-cycle chunk cost but its inputs (airport demographics +
+  // country relationships) barely change, so a fingerprint-invalidated cache serves
+  // most pairs for free. Off by default (multiplayer/default deploys unchanged); the
+  // cache is ~635MB at full dataset, so only enable with sufficient sim heap.
+  val demandMemoize : Boolean = boolAt("solo.demand.memoize", false)
+
   // Living-world dynamic AI (ComputerAirlineSimulation). Off by default. MVP is
   // drop-only: NPC airlines cancel persistently money-losing routes. Bounded per
   // cycle so it cannot destabilize the economy or blow the cycle budget.

--- a/airline-data/src/test/scala/com/patson/DemandGeneratorSpec.scala
+++ b/airline-data/src/test/scala/com/patson/DemandGeneratorSpec.scala
@@ -551,6 +551,51 @@ class DemandGeneratorSpec extends AnyWordSpecLike with Matchers {
       )
     }
 
+    "base-demand cache (Step E-1) should invalidate only changed airports".in {
+      // Synthetic airports so the test is independent of DB contents. A fingerprint
+      // covers income/population/popMiddleIncome/size/zone/countryCode/features.
+      def mk(iata: String, income: Int, pop: Int): Airport =
+        Airport(iata, s"K$iata", iata, 10.0, 10.0 + iata.hashCode % 30, "ZZ", iata, "North America", 5, income, pop, pop / 2, 0, 2000, math.abs(iata.hashCode) % 100000)
+
+      val a = mk("AAA", 30000, 1000000)
+      val b = mk("BBB", 25000, 800000)
+      val c = mk("CCC", 20000, 600000)
+      val airports = Array(a, b, c)
+      val epoch = 12345L
+
+      // First call must full-reset (cold cache) and seed all fingerprints.
+      val (reset1, changed1) = DemandGenerator.prepareBaseDemandCache(airports, epoch)
+      assert(reset1, "first call should full-reset")
+      assert(changed1 == airports.length)
+
+      // Re-running with identical airports + epoch evicts nothing.
+      val (reset2, changed2) = DemandGenerator.prepareBaseDemandCache(airports, epoch)
+      assert(!reset2, "unchanged world should not full-reset")
+      assert(changed2 == 0, s"unchanged world should evict nothing, evicted $changed2")
+
+      // Mutate one airport (new instance, higher income) -> exactly one eviction.
+      val bChanged = mk("BBB", 40000, 800000)
+      val (reset3, changed3) = DemandGenerator.prepareBaseDemandCache(Array(a, bChanged, c), epoch)
+      assert(!reset3, "single demographic change should be incremental, not a full reset")
+      assert(changed3 == 1, s"only the mutated airport should be evicted, evicted $changed3")
+
+      // Same world again -> stable, no eviction (fingerprint was updated).
+      val (reset4, changed4) = DemandGenerator.prepareBaseDemandCache(Array(a, bChanged, c), epoch)
+      assert(!reset4 && changed4 == 0, s"world stable again should evict nothing, evicted $changed4")
+
+      // A relationship-epoch change is a global input -> full reset.
+      val (reset5, _) = DemandGenerator.prepareBaseDemandCache(Array(a, bChanged, c), epoch + 1)
+      assert(reset5, "relationship epoch change should full-reset")
+
+      // Adding an airport changes membership/order -> full reset.
+      val (reset6, _) = DemandGenerator.prepareBaseDemandCache(Array(a, bChanged, c, mk("DDD", 15000, 400000)), epoch + 1)
+      assert(reset6, "membership change should full-reset")
+
+      // Fingerprint sanity: same demographics hash equal, changed income differs.
+      assert(DemandGenerator.airportFingerprint(b) == DemandGenerator.airportFingerprint(mk("BBB", 25000, 800000)))
+      assert(DemandGenerator.airportFingerprint(b) != DemandGenerator.airportFingerprint(bChanged))
+    }
+
     "computeDemand should have no PassengerType exceeding 35% of total demand".in {
       // Load airport stats from database
       val airportStatsList = AirportStatisticsSource.loadAllAirportStats()


### PR DESCRIPTION
## Step E-1: base-demand memoization

Caches the deterministic `computeBaseDemandBetweenAirports` result per ordered airport pair so it isn't recomputed every cycle. E-0 measured the base layer at ~1000s thread-time/cycle vs ~18s for the randomized chunk layer (~55x), and its inputs (airport demographics + country relationships) barely change cycle-to-cycle.

**Representation:** dense primitive int matrix, 12 ints/pair (3 LinkClassValues × economy/business/first/discount), keyed by airport index in the loaded list. ~635MB at N=3638 — vs ~3GB for a `HashMap[Int, Demand]` of objects (LinkClassValues carry stored `total`/`totalwithSeatSize` vals → ~230B/entry). The cheap caches that fit don't help: `Math.pow` is ~1s of the 1000s; the cost is the per-pair feature loops + Map allocations, so the full `Demand` must be cached.

**Invalidation** (single-threaded, before the `airports.par` loop): a per-airport demographic fingerprint (income/population/popMiddleIncome/size/zone/countryCode/features) evicts changed rows+columns; a change to airport membership/order or the country-relationship epoch full-resets. Inside the parallel loop each fromAirport owns exactly one row → lock-free.

**Gated behind `solo.demand.memoize` (default false)** — multiplayer/default deploys are byte-identical (the cache object is never touched when off). Not enabled in the deploy here; that follows once sim heap is raised to fit the ~635MB (container limit + Xmx bump).

Spec covers fingerprint equality + incremental vs full-reset eviction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)