### PR TITLE
perf(demand): enable base-demand memoization on OptiPlex (Step E-1)

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -29,15 +29,17 @@ jobs:
           # solo.*: friendlier single-player economy + financial notifications
           # (see com.patson.data.SoloConfig). Tune these freely — they only
           # affect this self-hosted instance.
+          # -Xmx2816M: headroom for the ~635MB Step E-1 base-demand cache on top
+          # of the ~1.8G working set (container mem_limit raised to match).
           SIM_EXTRA_OPTS: >-
-            -Xmx2048M
+            -Xmx2816M
             -Dsolo.ap.generationRate=0.3
             -Dsolo.loan.defaultAnnualRate=0.06
             -Dsolo.bankruptcy.cashThreshold=-25000000
             -Dsolo.bankruptcy.assetsThreshold=-150000000
             -Dsolo.notify.enabled=true
             -Dsolo.ai.enabled=true
-            -Dsolo.demand.profile=true
+            -Dsolo.demand.memoize=true
           # Web process (sign-up + tooltips): starting capital and the same
           # economy display values so tooltips match the simulation.
           WEB_SOLO_OPTS: >-

--- a/.github/workflows/read-sim-measurement.yml
+++ b/.github/workflows/read-sim-measurement.yml
@@ -26,11 +26,19 @@ jobs:
             'grep -aE "demand-cache-size|demand-profile|Loaded .* airports" /home/airline/sim.log | tail -20' \
             || echo "no matching lines yet (cycle may not have reached demand generation)"
           echo "=== MEASUREMENT-END ==="
+          # Step E-1: container memory + JVM heap, to confirm the ~635MB base-demand
+          # cache fits the raised sim heap without OOMing the unmanaged sim process.
+          echo "=== HEAP-BEGIN ==="
+          docker stats --no-stream airline-app || echo "no docker stats"
+          docker exec airline-app sh -c \
+            'jcmd $(pgrep -f MainSimulation | head -1) GC.heap_info 2>/dev/null' \
+            || echo "no jcmd heap info"
+          echo "=== HEAP-END ==="
           {
             echo "## Demand measurement (latest matches in sim.log)"
             echo '```'
             docker exec airline-app sh -c \
-              'grep -aE "demand-cache-size|demand-profile|Loaded .* airports" /home/airline/sim.log | tail -20' \
+              'grep -aE "demand-cache-size|demand-profile|demand-memoize|Loaded .* airports" /home/airline/sim.log | tail -20' \
               || echo "no matching lines yet"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docker-compose.small.yaml
+++ b/docker-compose.small.yaml
@@ -34,8 +34,9 @@ services:
     # No-op on hosts without AppArmor.
     security_opt:
       - apparmor=unconfined
-    # Holds both the simulation JVM (~2G heap) and the web JVM (~1G heap).
-    mem_limit: 4096m
+    # Holds both the simulation JVM (~2.75G heap with the Step E-1 base-demand
+    # cache, solo.demand.memoize) and the web JVM (~1G heap).
+    mem_limit: 5632m
     ports:
       - "9000:9000"
     healthcheck:


### PR DESCRIPTION
Enables the Step E-1 cache (#47) on the self-hosted instance and sizes the heap for it.

- `SIM_EXTRA_OPTS`: `-Xmx2048M`→`-Xmx2816M`, add `-Dsolo.demand.memoize=true`, drop the one-shot `-Dsolo.demand.profile` (E-0 captured: N=3638, validPairs=13.2M, base-demand ~1000s/cycle).
- `docker-compose.small.yaml`: airline-app `mem_limit` 4096m→5632m (host has headroom; LXC 202 cap is 16 GiB).
- Read Sim Measurement helper: add a HEAP block (docker stats + GC.heap_info) and the `[demand-memoize]` line for headless post-deploy verification.

Supersedes #46 (heap readout). After deploy I'll confirm via the reader: heap fits under 2816M with no OOM, `[demand-memoize]` shows full-reset on cycle 1 then incremental, and demand-chunk counts match the memoize-off baseline within randomizer noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)