### PR TITLE
feat(web): surface sim-control (speed/fast-forward) on mobile

### DIFF
--- a/airline-web/app/views/fragments/navbar.scala.html
+++ b/airline-web/app/views/fragments/navbar.scala.html
@@ -1,6 +1,10 @@
 
 	<div style="display: none;" class="extendedTopBarDetails flex-row items-center gap-1">
         <p class="tooltip-attr tooltip-attr-bottom" data-tooltip="An estimate of how long until next week."><img src='@routes.Assets.versioned("/images/icons/clock-moon-phase.png")' style="vertical-align: middle;"><span class="nextTickEstimation label" style="font-weight: bold;">Estimating...</span></p>
+        <p class="flex-row items-center gap-1" style="margin: 0;">
+            <span class="clickable label" onclick="promptSimSpeed()" title="Change simulation speed (minutes per game week)">&#9881; Speed</span>
+            <span class="clickable label" onclick="promptFastForward()" title="Fast-forward: run the next N weeks back-to-back">&#9193; Fast-fwd</span>
+        </p>
         <div style="display: none; margin-right: auto;" id="logoutDivMobile">
             <span id="currentUserNameMobile" class="label"></span>
             <a id="airlineSwitcherBtnMobile">


### PR DESCRIPTION
The sim speed (⚙) and fast-forward (⏩) buttons were only in the `desktopOnly` top bar, so they were invisible on mobile. This mirrors them into the `extendedTopBarDetails` overflow panel (the mobile "more" tab) with visible "Speed" / "Fast-fwd" labels — same duplication pattern already used for the next-tick estimate.

Verified the other solo features already work on mobile: solo-mode hiding targets the single shared `sidebar` (`data-link` rivals/alliance/champions) + `#live-chat`, and financial notifications live in the always-on top bar.

Pairs with #49 (the fast-forward URL fix).