### PR TITLE
feat(solo): milestone progression — achievements + progress (Phase G)

### DIFF
--- a/airline-data/src/main/scala/com/patson/AirlineSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/AirlineSimulation.scala
@@ -309,6 +309,9 @@ object AirlineSimulation {
       reputationBreakdowns.append(ReputationBreakdown(ReputationType.LEADERBOARD_BONUS, reputationBonusFromLeaderboards, reputationBonusFromLeaderboards.toInt))
 
       val milestones = AirlineMilestones.getMilestonesForAirlineType(airline.airlineType)
+      // Phase G: emit a one-time achievement notification when the player airline crosses
+      // a milestone tier (gated; player airlines only). Deduped by targetId per tier.
+      val trackProgression = SoloConfig.progressionEnabled && airline.airlineType != NonPlayerAirline && !isBankrupt
 
       milestones.foreach { milestone =>
         val (milestoneValue, reputationType) = milestone.name match {
@@ -395,6 +398,15 @@ object AirlineSimulation {
 
         val reputation = AirlineMilestones.evaluateMilestone(milestone, milestoneValue.toLong)
         reputationBreakdowns.append(ReputationBreakdown(reputationType, reputation, milestoneValue.toLong))
+
+        AirlineMilestones.milestoneNotificationsToEmit(trackProgression, milestone, milestoneValue.toLong,
+          threshold => NotificationSource.existsByTargetId(airline.id, s"milestone_${milestone.name}_$threshold", NotificationCategory.MILESTONE_ACHIEVED)
+        ).foreach { condition =>
+          val targetId = s"milestone_${milestone.name}_${condition.threshold}"
+          NotificationSource.insertNotification(Notification(airline.id, NotificationCategory.MILESTONE_ACHIEVED,
+            s"Milestone reached: ${String.format("%,d", condition.threshold)} ${milestone.description} (+${condition.reward} reputation)",
+            cycle, targetId = Some(targetId)))
+        }
       }
 
       if (airline.airlineType.airportRepRatio > 0) {

--- a/airline-data/src/main/scala/com/patson/data/NotificationSource.scala
+++ b/airline-data/src/main/scala/com/patson/data/NotificationSource.scala
@@ -56,11 +56,16 @@ object NotificationSource {
     }
   }
 
+  // Categories exempt from the retention purge: live link-cancellation alerts (managed by
+  // LinkSimulation) and milestone achievements (a permanent record of what the player earned).
+  private val PURGE_EXEMPT_CATEGORIES = List(NotificationCategory.LINK_CANCELLATION, NotificationCategory.MILESTONE_ACHIEVED)
+  private val purgeExemptClause = PURGE_EXEMPT_CATEGORIES.map(c => s"'$c'").mkString("category NOT IN (", ", ", ")")
+
   private def purgeOldNotifications(airlineId: Int): Unit = {
     val connection = Meta.getConnection()
     try {
       val statement = connection.prepareStatement(
-        s"DELETE FROM $NOTIFICATION_TABLE WHERE airline = ? AND category != '${NotificationCategory.LINK_CANCELLATION}' AND id NOT IN (SELECT id FROM (SELECT id FROM $NOTIFICATION_TABLE WHERE airline = ? AND category != '${NotificationCategory.LINK_CANCELLATION}' ORDER BY id DESC LIMIT $RETENTION_LIMIT) AS t)"
+        s"DELETE FROM $NOTIFICATION_TABLE WHERE airline = ? AND $purgeExemptClause AND id NOT IN (SELECT id FROM (SELECT id FROM $NOTIFICATION_TABLE WHERE airline = ? AND $purgeExemptClause ORDER BY id DESC LIMIT $RETENTION_LIMIT) AS t)"
       )
       try {
         statement.setInt(1, airlineId)
@@ -268,6 +273,28 @@ object NotificationSource {
       try {
         statement.setInt(1, airlineId)
         statement.executeUpdate()
+      } finally {
+        statement.close()
+      }
+    } finally {
+      connection.close()
+    }
+  }
+
+  // True if a notification already exists for this (airline, target, category) — used to
+  // fire a milestone achievement exactly once per tier.
+  def existsByTargetId(airlineId: Int, targetId: String, category: NotificationCategory.Value): Boolean = {
+    val connection = Meta.getConnection()
+    try {
+      val statement = connection.prepareStatement(
+        s"SELECT 1 FROM $NOTIFICATION_TABLE WHERE airline = ? AND target_id = ? AND category = ? LIMIT 1"
+      )
+      try {
+        statement.setInt(1, airlineId)
+        statement.setString(2, targetId)
+        statement.setString(3, category.toString)
+        val rs = statement.executeQuery()
+        rs.next()
       } finally {
         statement.close()
       }

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -58,4 +58,9 @@ object SoloConfig {
   val aiMaxDropsPerAirline : Int = intAt("solo.ai.maxDropsPerAirline", 1)
   val aiLossLookbackCycles : Int = intAt("solo.ai.lossLookbackCycles", 4)
   val aiDropProfitThreshold : Long = longAt("solo.ai.dropProfitThreshold", -500000L)
+
+  // Solo progression (Phase G): surface the already-computed milestone system to the
+  // player as one-time achievement notifications + a progress view. Off by default so
+  // multiplayer/default deploys are unchanged (no notifications, no behavior change).
+  val progressionEnabled : Boolean = boolAt("solo.progression.enabled", false)
 }

--- a/airline-data/src/main/scala/com/patson/model/AirlineMilestone.scala
+++ b/airline-data/src/main/scala/com/patson/model/AirlineMilestone.scala
@@ -339,4 +339,18 @@ object AirlineMilestones {
       .map(_.reward)
       .getOrElse(0)
   }
-} 
+
+  /**
+   * Milestone tiers that should produce a one-time achievement notification (Phase G).
+   * Pure / no I/O so it is unit-testable: returns the conditions met at `value` that are
+   * not already recorded, but only when `track` is set (progression on, player airline).
+   *
+   * @param track          whether progression tracking applies (solo flag + player airline)
+   * @param value          the airline's current value for this milestone
+   * @param alreadyAchieved predicate: has this threshold already been notified?
+   */
+  def milestoneNotificationsToEmit(track: Boolean, milestone: Milestone, value: Long, alreadyAchieved: Long => Boolean): List[MilestoneCondition] = {
+    if (!track) Nil
+    else milestone.conditions.filter(condition => condition.threshold <= value && !alreadyAchieved(condition.threshold))
+  }
+}

--- a/airline-data/src/main/scala/com/patson/model/Notification.scala
+++ b/airline-data/src/main/scala/com/patson/model/Notification.scala
@@ -51,6 +51,11 @@ object NotificationCategory extends Enumeration {
    *
    * PROFIT_MILESTONE — Single-player: player airline weekly profit crossed the
    *   configured milestone (gated by solo.notify.enabled). targetId: "profit".
+   *
+   * MILESTONE_ACHIEVED — Single-player progression (gated by solo.progression.enabled):
+   *   the player airline crossed a milestone tier (AirlineMilestones). One per tier, ever.
+   *   targetId: "milestone_{name}_{threshold}"; exempt from the retention purge so the
+   *   achievement record persists.
    */
-  val NEGOTIATION_LOSS, LEVEL_UP, LOYALIST, GAME_OVER, OLYMPICS_PRIZE, TUTORIAL, LINK_CANCELLATION, CASH_FLOW_WARNING, PROFIT_MILESTONE = Value
+  val NEGOTIATION_LOSS, LEVEL_UP, LOYALIST, GAME_OVER, OLYMPICS_PRIZE, TUTORIAL, LINK_CANCELLATION, CASH_FLOW_WARNING, PROFIT_MILESTONE, MILESTONE_ACHIEVED = Value
 }

--- a/airline-data/src/test/scala/com/patson/AirlineMilestoneSpec.scala
+++ b/airline-data/src/test/scala/com/patson/AirlineMilestoneSpec.scala
@@ -1,0 +1,49 @@
+package com.patson
+
+import com.patson.model.{AirlineMilestones, Milestone, MilestoneCondition}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+/**
+ * Phase G: milestone achievement emission logic. Tests the pure decision helper
+ * `AirlineMilestones.milestoneNotificationsToEmit` (no DB), which the simulation uses to
+ * decide which milestone tiers should fire a one-time achievement notification.
+ */
+class AirlineMilestoneSpec extends AnyWordSpecLike with Matchers {
+  // Two-tier milestone (highest threshold first, as in the real definitions).
+  val milestone = Milestone("MILESTONE_DESTINATIONS", "Destinations",
+    List(MilestoneCondition(150, 60), MilestoneCondition(50, 30)))
+
+  val nothingAchieved: Long => Boolean = _ => false
+
+  "milestoneNotificationsToEmit".must {
+    "emit nothing when tracking is off (progression disabled or NPC airline)".in {
+      AirlineMilestones.milestoneNotificationsToEmit(track = false, milestone, 9999, nothingAchieved) shouldBe empty
+    }
+
+    "emit nothing when the value is below every threshold".in {
+      AirlineMilestones.milestoneNotificationsToEmit(track = true, milestone, 30, nothingAchieved) shouldBe empty
+    }
+
+    "emit only the tiers met when crossing the lower tier".in {
+      val emitted = AirlineMilestones.milestoneNotificationsToEmit(track = true, milestone, 60, nothingAchieved)
+      emitted.map(_.threshold) should contain theSameElementsAs List(50L)
+    }
+
+    "emit all met tiers when jumping past both at once".in {
+      val emitted = AirlineMilestones.milestoneNotificationsToEmit(track = true, milestone, 200, nothingAchieved)
+      emitted.map(_.threshold) should contain theSameElementsAs List(150L, 50L)
+    }
+
+    "not re-emit a tier already achieved (idempotent)".in {
+      val only50Done: Long => Boolean = t => t == 50L
+      val emitted = AirlineMilestones.milestoneNotificationsToEmit(track = true, milestone, 200, only50Done)
+      emitted.map(_.threshold) should contain theSameElementsAs List(150L)
+    }
+
+    "emit nothing once every met tier is already achieved".in {
+      val allDone: Long => Boolean = _ => true
+      AirlineMilestones.milestoneNotificationsToEmit(track = true, milestone, 200, allDone) shouldBe empty
+    }
+  }
+}

--- a/airline-web/public/javascripts/office.js
+++ b/airline-web/public/javascripts/office.js
@@ -424,7 +424,6 @@ function writeMilestones(breakdowns) {
     const milestones = gameConstants.milestones[activeAirline.type] || gameConstants.milestones.Legacy
 
     milestones.forEach(milestone => {
-        const currentValue = breakdowns[milestone.name] ? breakdowns[milestone.name].value : 0;
         const currentQuantityValue = breakdowns[milestone.name] ? breakdowns[milestone.name].quantityValue : 0;
 
         const $col = $("<div></div>")
@@ -433,8 +432,21 @@ function writeMilestones(breakdowns) {
             `<p class="pb-1 opacity-70 italic">@ ${commaSeparateNumber(currentQuantityValue)}</p>`,
         );
 
+        // Progress toward the next unmet tier (lowest threshold above the current value).
+        const nextTier = milestone.conditions.slice().sort((a, b) => a.threshold - b.threshold)
+            .find(cond => currentQuantityValue < cond.threshold);
+        if (nextTier) {
+            const pct = Math.min(100, Math.round(currentQuantityValue / nextTier.threshold * 100));
+            $col.append(
+                `<div style="width:160px;height:6px;border-radius:4px;background:rgba(0,0,0,0.25);overflow:hidden;margin-bottom:4px;" title="${pct}% to ${commaSeparateNumber(nextTier.threshold)}">
+                    <div style="height:100%;width:${pct}%;background:gold;"></div>
+                </div>`);
+        } else {
+            $col.append(`<p class="pb-1" style="color:gold;font-size:11px;">All tiers complete ✓</p>`);
+        }
+
         milestone.conditions.forEach(cond => {
-            const metCondtion = currentValue >= cond.reward ? "tick" : "cross";
+            const metCondtion = currentQuantityValue >= cond.threshold ? "tick" : "cross";
             $col.append(
                 `<div style="width: 160px;justify-content: space-between;" class="flex-row py-1">
 					<div class="font-mono text-sm flex-align-center">


### PR DESCRIPTION
Lights up the existing-but-invisible milestone system as solo progression. Gated behind `solo.progression.enabled` (default false → multiplayer/default deploys byte-identical; the cache object/notifications are never touched when off).

**G-1 — achievement notifications (backend)**
When the player airline crosses a milestone tier, fire a one-time `MILESTONE_ACHIEVED` notification (renders in the existing notification bell). Reuses the milestone values already computed every cycle in `AirlineSimulation`. The emission decision is a pure, unit-tested helper (`AirlineMilestones.milestoneNotificationsToEmit`); dedup via `NotificationSource.existsByTargetId` keyed by `milestone_<name>_<threshold>`; the category is exempt from the retention purge. Player airlines only, NPCs excluded.

**G-2 — progress dashboard (web)**
The Office page already had a milestone panel — discovered it compares earned-reputation `value` vs `cond.reward` for the achieved tick (works only because rewards happen to be monotonic). Fixed to the correct `currentQuantity >= threshold`, and added a progress bar toward the next unmet tier. No new endpoint needed — the current values are already exposed via the airline's reputation breakdown `quantityValue`.

Not enabled in the deploy here; a follow-up flips `-Dsolo.progression.enabled=true` after this compiles green (same pattern as Step E-1).