### PR TITLE
chore(deploy): enable solo milestone progression (Phase G)

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -40,6 +40,7 @@ jobs:
             -Dsolo.notify.enabled=true
             -Dsolo.ai.enabled=true
             -Dsolo.demand.memoize=true
+            -Dsolo.progression.enabled=true
           # Web process (sign-up + tooltips): starting capital and the same
           # economy display values so tooltips match the simulation.
           WEB_SOLO_OPTS: >-


### PR DESCRIPTION
Flips on `-Dsolo.progression.enabled=true` now that the Phase G code (#51) is merged and compile-gated. Player airline will get one-time milestone achievement notifications; the Office progress panel already renders current/next tiers.