### PR TITLE
balance(demand): reduce tourist seasonal oscillation (port from v5)

### DIFF
--- a/airline-data/src/main/scala/com/patson/DemandGenerator.scala
+++ b/airline-data/src/main/scala/com/patson/DemandGenerator.scala
@@ -39,17 +39,19 @@ object DemandGenerator {
   }
 
   def demandRandomizerByType(passengerType: PassengerType.Value, demand: Int, cycle: Int, cyclePhaseLength: Int): Int = {
+    // Seasonal amplitude/offset per pax type, ported from upstream v5 (reduced tourist
+    // oscillation to cut demand whiplash). Tourist amplitude is solo-tunable.
     val randomizedDemand = if (passengerType == PassengerType.TOURIST) {
-      demandRandomizer(demand, cycle, cyclePhaseLength, 2, 24)
+      demandRandomizer(demand, cycle, cyclePhaseLength, SoloConfig.demandTouristAmplitude, 30)
     } else if (passengerType == PassengerType.BUSINESS) {
-      demandRandomizer(demand, cycle, cyclePhaseLength, 1, 12)
+      demandRandomizer(demand, cycle, cyclePhaseLength, 1, 15)
     } else { //traveler, elite
       demandRandomizer(demand, cycle, cyclePhaseLength)
     }
     randomizedDemand
   }
 
-  def demandRandomizer(demand: Int, cycle: Int, frequency: Int, amplitudeRatio: Int = 1, offset: Int = 0): Int = {
+  def demandRandomizer(demand: Int, cycle: Int, frequency: Int, amplitudeRatio: Double = 1, offset: Int = 0): Int = {
     val baseSeasonalPct = 0.07  // The wave naturally swings +/- 8%
     val noisePct = 0.03
     val rng = ThreadLocalRandom.current()

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -63,4 +63,10 @@ object SoloConfig {
   // player as one-time achievement notifications + a progress view. Off by default so
   // multiplayer/default deploys are unchanged (no notifications, no behavior change).
   val progressionEnabled : Boolean = boolAt("solo.progression.enabled", false)
+
+  // Demand balance (ported from upstream v5): seasonal amplitude multiplier for TOURIST
+  // demand in DemandGenerator.demandRandomizerByType. Our fork inherited 2.0 (very strong
+  // tourist swings → routes whiplash between profitable and dead); upstream iteratively
+  // reduced this to 1.25. Exposed as a knob so it can be tuned live during playtest.
+  val demandTouristAmplitude : Double = doubleAt("solo.demand.touristAmplitude", 1.25)
 }


### PR DESCRIPTION
First selective cherry-pick from upstream v5's demand balance work.

**What & why:** our fork inherited TOURIST seasonal amplitude `2.0` in `demandRandomizerByType`; upstream iteratively cut it (2 → 1.5 → 1.25) because strong tourist oscillation whiplashes route profitability week to week. Adopt **1.25** and align phase offsets to v5 (tourist 24→30, business 12→15). `amplitudeRatio` widened to `Double`.

**Tunable:** exposed as `solo.demand.touristAmplitude` (default 1.25) so seasonality can be dialed live during playtest without a code change.

**Safety:** chunk-layer change, downstream of the Step E-1 base-demand cache — no cache-correctness impact. Verified the other v5 demand tweaks were *not* blindly portable (our fork is a mix — e.g. `PRICE_LAST_MIN_DEAL_MULTIPLIER` is already at v5's 0.88, and v5's locality maps live in a different structure than ours), so this PR is scoped to the one high-confidence, verified change.