### PR TITLE
feat(web): visible fast-forward progress indicator

### DIFF
--- a/airline-web/app/views/fragments/navbar.scala.html
+++ b/airline-web/app/views/fragments/navbar.scala.html
@@ -4,6 +4,7 @@
         <p class="flex-row items-center gap-1" style="margin: 0;">
             <span class="clickable label" onclick="promptSimSpeed()" title="Change simulation speed (minutes per game week)">&#9881; Speed</span>
             <span class="clickable label" onclick="promptFastForward()" title="Fast-forward: run the next N weeks back-to-back">&#9193; Fast-fwd</span>
+            <span class="fastForwardStatus label" style="display:none;color:gold;font-weight:bold;" title="Fast-forward weeks remaining"></span>
         </p>
         <div style="display: none; margin-right: auto;" id="logoutDivMobile">
             <span id="currentUserNameMobile" class="label"></span>
@@ -24,7 +25,7 @@
         <div class="topBarDetails">
             <p class="currentTime label tooltip-attr tooltip-attr-bottom desktopOnly" data-tooltip="One week lasts ~ 30min and one year is 48 weeks or 24 hours in realtime. "></p>
             <p class="tooltip-attr tooltip-attr-bottom desktopOnly" data-tooltip="An estimate of how long until next week."><img src='@routes.Assets.versioned("/images/icons/clock-moon-phase.png")' style="vertical-align: middle;"><span class="nextTickEstimation label" style="font-weight: bold;">Estimating...</span></p>
-            <p class="desktopOnly"><span class="clickable label tooltip-attr tooltip-attr-bottom" data-tooltip="Change simulation speed (minutes per game week)" onclick="promptSimSpeed()">&#9881;</span> <span class="clickable label tooltip-attr tooltip-attr-bottom" data-tooltip="Fast-forward: run the next N weeks back-to-back" onclick="promptFastForward()">&#9193;</span></p>
+            <p class="desktopOnly"><span class="clickable label tooltip-attr tooltip-attr-bottom" data-tooltip="Change simulation speed (minutes per game week)" onclick="promptSimSpeed()">&#9881;</span> <span class="clickable label tooltip-attr tooltip-attr-bottom" data-tooltip="Fast-forward: run the next N weeks back-to-back" onclick="promptFastForward()">&#9193;</span> <span class="fastForwardStatus label tooltip-attr tooltip-attr-bottom" data-tooltip="Fast-forward weeks remaining (each week still takes the normal compute time)" style="display:none;color:gold;font-weight:bold;"></span></p>
             <p class="tooltip-attr tooltip-attr-bottom" data-tooltip="Cash money">$<span class="balance"></span></p>
             <p class="tooltip-attr tooltip-attr-bottom actionPoints" data-tooltip="Action Points"></p>
             <div id="notificationBell" class="clickable relative pr-4" title="Notifications">

--- a/airline-web/public/javascripts/login.js
+++ b/airline-web/public/javascripts/login.js
@@ -214,6 +214,7 @@ async function doPostLoginSetup(user) {
         if (typeof loadAirportsDynamic === 'function') loadAirportsDynamic();
         if (typeof initAdminActions === 'function') initAdminActions();
         if (typeof loadAllCountries === 'function') loadAllCountries();
+        if (typeof refreshFastForwardStatus === 'function') refreshFastForwardStatus();
     } catch (e) {
         console.warn('Optional features setup error:', e);
     }

--- a/airline-web/public/javascripts/main.js
+++ b/airline-web/public/javascripts/main.js
@@ -203,9 +203,32 @@ function promptFastForward() {
 		url: "/sim-control/fast-forward/" + cycles,
 		dataType: 'json',
 		success: function(result) {
-			alert("Fast-forwarding " + result.fastForward + " week(s) starting after the current week completes")
+			// Surface progress in the top bar instead of a one-off modal. Each week still
+			// takes the normal compute time, so this is the only ongoing signal it worked.
+			renderFastForwardStatus(result.fastForward)
 		},
 		error: function(jqXHR) { alert(simControlError(jqXHR, "fast-forward the simulation")) }
+	})
+}
+
+// Show/hide the "N weeks left" fast-forward badge in the top bar + mobile panel.
+function renderFastForwardStatus(count) {
+	var n = count || 0
+	if (n > 0) {
+		$(".fastForwardStatus").text("⏩ " + n + " week" + (n === 1 ? "" : "s") + " left").show()
+	} else {
+		$(".fastForwardStatus").hide().text("")
+	}
+}
+
+// Poll the authoritative fast-forward count and update the badge. Called on load, on
+// fast-forward requests, and once per cycle (the count decrements as weeks complete).
+function refreshFastForwardStatus() {
+	$.ajax({
+		type: 'GET',
+		url: "/sim-control",
+		dataType: 'json',
+		success: function(control) { renderFastForwardStatus(control.fastForward) }
 	})
 }
 
@@ -252,6 +275,9 @@ function updateTime(cycle, fraction, cycleDurationEstimation) {
     }
 
 	currentTickTimer = tickTimerCreator()
+
+	// A new cycle just advanced (cycleInfo) — refresh the fast-forward countdown.
+	if (typeof refreshFastForwardStatus === 'function') refreshFastForwardStatus()
 }
 
 


### PR DESCRIPTION
Fast-forward was working (logs showed cycles running back-to-back on request) but **invisible** — the only feedback was a one-off alert, so during a ~10-min cycle it looked like nothing happened.

Adds a gold **"⏩ N weeks left"** badge in the top bar (desktop) and the mobile overflow panel, fed by the existing `GET /sim-control` `fastForward` count. Refreshed: on load (`doPostLoginSetup`), on each fast-forward request (replacing the modal alert), and once per cycle via `updateTime` (the websocket `cycleInfo` hook) so it counts down as weeks complete and disappears at zero.

Web-only; tooltip notes that each week still takes normal compute time (the cycle speed is bounded by the CPU, not this feature).