### PR TITLE
feat(solo): standalone lounges + lower alliance minimum

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -41,8 +41,11 @@ jobs:
             -Dsolo.ai.enabled=true
             -Dsolo.demand.memoize=true
             -Dsolo.progression.enabled=true
+            -Dsolo.alliance.minMembers=2
           # Web process (sign-up + tooltips): starting capital and the same
           # economy display values so tooltips match the simulation.
+          # alliance.minMembers must match the sim so alliance status agrees across JVMs;
+          # lounge.allowWithoutAlliance gates the web-side lounge build.
           WEB_SOLO_OPTS: >-
             -Dsolo.startingBalance=25000000
             -Dsolo.minRenewalBalance=100000
@@ -50,6 +53,8 @@ jobs:
             -Dsolo.loan.defaultAnnualRate=0.06
             -Dsolo.bankruptcy.cashThreshold=-25000000
             -Dsolo.bankruptcy.assetsThreshold=-150000000
+            -Dsolo.lounge.allowWithoutAlliance=true
+            -Dsolo.alliance.minMembers=2
         run: bash scripts/optiplex-deploy.sh
 
       - name: Install e2e dependencies

--- a/airline-data/src/main/scala/com/patson/AirportSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/AirportSimulation.scala
@@ -281,7 +281,10 @@ object AirportSimulation {
 
         airport.getLounges().foreach { lounge =>
           val newStatus =
-            if (lounge.allianceId.exists(eligibleAllianceIds.contains)) {
+            // Airline-owned lounges (no alliance, solo.lounge.allowWithoutAlliance) are not
+            // subject to alliance ranking — keep them active. Alliance lounges still must
+            // rank in the top N by premium pax.
+            if (lounge.allianceId.isEmpty || lounge.allianceId.exists(eligibleAllianceIds.contains)) {
               LoungeStatus.ACTIVE
             } else {
               LoungeStatus.INACTIVE

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -69,4 +69,12 @@ object SoloConfig {
   // tourist swings → routes whiplash between profitable and dead); upstream iteratively
   // reduced this to 1.25. Exposed as a knob so it can be tuned live during playtest.
   val demandTouristAmplitude : Double = doubleAt("solo.demand.touristAmplitude", 1.25)
+
+  // Lounges & alliances (single-player). Lounges are an alliance facility upstream, but
+  // the sim already supports airline-owned lounges (Airport.getLounge is airline-first);
+  // allowWithoutAlliance lets a solo airline build one standalone (benefits its own premium
+  // pax, no codeshare impact). allianceMinMembers lowers the count at which an alliance
+  // becomes ESTABLISHED (upstream 3) so a player's own 2 airlines can form a real alliance.
+  val loungeWithoutAlliance : Boolean = boolAt("solo.lounge.allowWithoutAlliance", false)
+  val allianceMinMembers : Int = intAt("solo.alliance.minMembers", 3)
 }

--- a/airline-data/src/main/scala/com/patson/model/Alliance.scala
+++ b/airline-data/src/main/scala/com/patson/model/Alliance.scala
@@ -74,7 +74,9 @@ object AllianceEvent extends Enumeration {
 object Alliance {
   val MAX_MEMBER_NON_REGIONAL_COUNT = 7
   val MAX_MEMBER_REGIONALS_COUNT = 0
-  val ESTABLISH_MIN_MEMBER_COUNT = 3
+  // Members required for an alliance to become ESTABLISHED (vs FORMING). Defaults to the
+  // upstream 3; solo.alliance.minMembers can lower it so a player's own 2 airlines qualify.
+  val ESTABLISH_MIN_MEMBER_COUNT = com.patson.data.SoloConfig.allianceMinMembers
 
   /**
     *

--- a/airline-web/app/controllers/AirlineApplication.scala
+++ b/airline-web/app/controllers/AirlineApplication.scala
@@ -442,9 +442,15 @@ class AirlineApplication @Inject()(cc: ControllerComponents) extends AbstractCon
       return Consideration(cost, newLounge, Some("Cannot build lounge without a base"))
     }
 
-    //alliance
-    if (! airline.getAllianceId().isDefined) {
+    //alliance — solo airlines may build airline-owned lounges without one
+    //(solo.lounge.allowWithoutAlliance). The sim already supports airline-owned lounges;
+    //they benefit this airline's own premium pax and have no alliance/codeshare interaction.
+    val allowSoloLounge = SoloConfig.loungeWithoutAlliance && airline.getAllianceId().isEmpty
+    if (airline.getAllianceId().isEmpty && !allowSoloLounge) {
       return Consideration(cost, newLounge, Some("Must be in an alliance to build/upgrade lounge"))
+    }
+    if (allowSoloLounge) {
+      return Consideration(cost, newLounge) //airline-owned lounge: no alliance ranking requirement
     }
 
     //check whether it fulfills ranking requirement

--- a/airline-web/app/views/fragments/navbar.scala.html
+++ b/airline-web/app/views/fragments/navbar.scala.html
@@ -4,6 +4,7 @@
         <p class="flex-row items-center gap-1" style="margin: 0;">
             <span class="clickable label" onclick="promptSimSpeed()" title="Change simulation speed (minutes per game week)">&#9881; Speed</span>
             <span class="clickable label" onclick="promptFastForward()" title="Fast-forward: run the next N weeks back-to-back">&#9193; Fast-fwd</span>
+            <span class="fastForwardStatus label" style="display:none;color:gold;font-weight:bold;" title="Fast-forward weeks remaining"></span>
         </p>
         <div style="display: none; margin-right: auto;" id="logoutDivMobile">
             <span id="currentUserNameMobile" class="label"></span>
@@ -24,7 +25,7 @@
         <div class="topBarDetails">
             <p class="currentTime label tooltip-attr tooltip-attr-bottom desktopOnly" data-tooltip="One week lasts ~ 30min and one year is 48 weeks or 24 hours in realtime. "></p>
             <p class="tooltip-attr tooltip-attr-bottom desktopOnly" data-tooltip="An estimate of how long until next week."><img src='@routes.Assets.versioned("/images/icons/clock-moon-phase.png")' style="vertical-align: middle;"><span class="nextTickEstimation label" style="font-weight: bold;">Estimating...</span></p>
-            <p class="desktopOnly"><span class="clickable label tooltip-attr tooltip-attr-bottom" data-tooltip="Change simulation speed (minutes per game week)" onclick="promptSimSpeed()">&#9881;</span> <span class="clickable label tooltip-attr tooltip-attr-bottom" data-tooltip="Fast-forward: run the next N weeks back-to-back" onclick="promptFastForward()">&#9193;</span></p>
+            <p class="desktopOnly"><span class="clickable label tooltip-attr tooltip-attr-bottom" data-tooltip="Change simulation speed (minutes per game week)" onclick="promptSimSpeed()">&#9881;</span> <span class="clickable label tooltip-attr tooltip-attr-bottom" data-tooltip="Fast-forward: run the next N weeks back-to-back" onclick="promptFastForward()">&#9193;</span> <span class="fastForwardStatus label tooltip-attr tooltip-attr-bottom" data-tooltip="Fast-forward weeks remaining (each week still takes the normal compute time)" style="display:none;color:gold;font-weight:bold;"></span></p>
             <p class="tooltip-attr tooltip-attr-bottom" data-tooltip="Cash money">$<span class="balance"></span></p>
             <p class="tooltip-attr tooltip-attr-bottom actionPoints" data-tooltip="Action Points"></p>
             <div id="notificationBell" class="clickable relative pr-4" title="Notifications">

--- a/airline-web/public/javascripts/login.js
+++ b/airline-web/public/javascripts/login.js
@@ -214,6 +214,7 @@ async function doPostLoginSetup(user) {
         if (typeof loadAirportsDynamic === 'function') loadAirportsDynamic();
         if (typeof initAdminActions === 'function') initAdminActions();
         if (typeof loadAllCountries === 'function') loadAllCountries();
+        if (typeof refreshFastForwardStatus === 'function') refreshFastForwardStatus();
     } catch (e) {
         console.warn('Optional features setup error:', e);
     }

--- a/airline-web/public/javascripts/main.js
+++ b/airline-web/public/javascripts/main.js
@@ -203,9 +203,32 @@ function promptFastForward() {
 		url: "/sim-control/fast-forward/" + cycles,
 		dataType: 'json',
 		success: function(result) {
-			alert("Fast-forwarding " + result.fastForward + " week(s) starting after the current week completes")
+			// Surface progress in the top bar instead of a one-off modal. Each week still
+			// takes the normal compute time, so this is the only ongoing signal it worked.
+			renderFastForwardStatus(result.fastForward)
 		},
 		error: function(jqXHR) { alert(simControlError(jqXHR, "fast-forward the simulation")) }
+	})
+}
+
+// Show/hide the "N weeks left" fast-forward badge in the top bar + mobile panel.
+function renderFastForwardStatus(count) {
+	var n = count || 0
+	if (n > 0) {
+		$(".fastForwardStatus").text("⏩ " + n + " week" + (n === 1 ? "" : "s") + " left").show()
+	} else {
+		$(".fastForwardStatus").hide().text("")
+	}
+}
+
+// Poll the authoritative fast-forward count and update the badge. Called on load, on
+// fast-forward requests, and once per cycle (the count decrements as weeks complete).
+function refreshFastForwardStatus() {
+	$.ajax({
+		type: 'GET',
+		url: "/sim-control",
+		dataType: 'json',
+		success: function(control) { renderFastForwardStatus(control.fastForward) }
 	})
 }
 
@@ -252,6 +275,9 @@ function updateTime(cycle, fraction, cycleDurationEstimation) {
     }
 
 	currentTickTimer = tickTimerCreator()
+
+	// A new cycle just advanced (cycleInfo) — refresh the fast-forward countdown.
+	if (typeof refreshFastForwardStatus === 'function') refreshFastForwardStatus()
 }
 
 


### PR DESCRIPTION
Unblocks the solo lounge/alliance experience (player hit "need an alliance" to build a lounge, and "need 3 members" to form an alliance).

**Lounges without an alliance** (`solo.lounge.allowWithoutAlliance`): the sim already supports airline-owned lounges — `Airport.getLounge` is airline-first and `Lounge.allianceId` is `Option`. Skip the alliance + ranking gate in `getLoungeConsideration` so a solo airline builds a standalone lounge that benefits its **own** premium pax (`FlightPreference.loungeAdjust`). No codeshare interaction — that's a separate alliance mechanic.

**Critical sim fix:** `AirportSimulation.updateLoungeStatus` would flip a no-alliance lounge to INACTIVE every cycle (`allianceId.exists(...)` is false for `None`). Now airline-owned lounges stay ACTIVE; alliance lounges still need the top-N premium-pax rank.

**Lower alliance minimum** (`solo.alliance.minMembers`, default 3): `Alliance.ESTABLISH_MIN_MEMBER_COUNT` is now configurable. Deploy sets **2** (in both sim + web opts, so `status` agrees across JVMs) so your own two regional airlines can form an ESTABLISHED alliance with real codeshare + shared lounges — the optional "group" playstyle — without forcing it.

Defaults keep multiplayer byte-identical.