### PR TITLE
fix(web): main content panel fills the canvas

### DIFF
--- a/airline-web/public/stylesheets/main.css
+++ b/airline-web/public/stylesheets/main.css
@@ -868,6 +868,16 @@ li.row, div.table-row {
     box-sizing: border-box;
     overflow-x: scroll;
     max-width: 100%;
+    -webkit-overflow-scrolling: touch;
+}
+
+/* The main content panel sits in a flex .canvas. Without a grow factor it shrinks to
+   its content width, leaving large dead space on wide screens and forcing tables (e.g.
+   the flights list) to scroll/truncate. Let it fill the canvas; any side panel keeps its
+   own width. min-width:0 lets inner scroll containers shrink instead of overflowing. */
+.mainPanel {
+    flex: 1 1 0%;
+    min-width: 0;
 }
 
 .table.data {


### PR DESCRIPTION
First UI pass from the Playwright audit. `.mainPanel` sits in a flex `.canvas` but had no grow factor, so it shrank to content width — leaving large dead space on wide screens and forcing the flights table to scroll and truncate (Revenue clipped, as reported).

Fix: `.mainPanel { flex: 1 1 0%; min-width: 0 }` so it fills the canvas; side panels keep their width. Verified via Playwright (logged in as the dev airline): flights table **980px → ~1850px**, all columns visible; `/country` and `/hangar` side-panel layouts unaffected and wider. Also `-webkit-overflow-scrolling: touch` on horizontal table containers.

Affects `/flights`, `/country`, `/hangar`, `/map` (all use `.mainPanel`). CSS-only.

Follow-ups identified (separate PRs): bank/oil vertical-space use (ChartJS sizing) and a mobile responsive-table treatment.