### PR TITLE
feat(web): mobile card view for the flights list

### DIFF
--- a/airline-web/public/javascripts/airline.js
+++ b/airline-web/public/javascripts/airline.js
@@ -2156,19 +2156,19 @@ function updateLinksTable(sortProperty, sortOrder) {
         rowsHtml.push(
             `<div class='table-row clickable${selectedClass}' data-link-id='${link.id}'${bgStyle}>` +
             `<div class='cell'><input type='checkbox' class='link-checkbox'${checkedAttr}></div>` +
-            `<div class='cell'>${getCountryFlagImg(link.fromCountryCode)}${getAirportText(link.fromAirportCity, link.fromAirportCode)}</div>` +
-            `<div class='cell'>${getCountryFlagImg(link.toCountryCode)}${getAirportText(link.toAirportCity, link.toAirportCode)}</div>` +
-            `<div class='cell'>${link.model}</div>` +
-            `<div class='cell' align='right'>${Math.round(convertDistance(link.distance))}${distanceLabel()}</div>` +
-            `<div class='cell' align='right'>${link.totalCapacity}(${link.frequency})</div>` +
-            `<div class='cell' align='right'>${quality}</div>` +
-            `<div class='cell${avgClass}' align='right'>${link.displayLoadFactor}%</div>` +
-            `<div class='cell${avgClass}' align='right'>${Math.round(link.displaySatisfaction * 100)}%</div>` +
-            `<div class='cell${avgClass}' align='right'>$${commaSeparateNumber(link.revenue)}</div>` +
-            `<div class='cell${avgClass}' align='right'>$${commaSeparateNumber(link.displayProfit)}</div>` +
-            `<div class='cell${avgClass}' align='right'>${(link.displayProfitMargin * 100).toFixed(2)}%</div>` +
-            `<div class='cell' align='right'>${link.currentStaffRequired}</div>` +
-            `<div class='cell' align='right'>$${commaSeparateNumber(link.profitPerStaff)}</div>` +
+            `<div class='cell' data-label='From'>${getCountryFlagImg(link.fromCountryCode)}${getAirportText(link.fromAirportCity, link.fromAirportCode)}</div>` +
+            `<div class='cell' data-label='To'>${getCountryFlagImg(link.toCountryCode)}${getAirportText(link.toAirportCity, link.toAirportCode)}</div>` +
+            `<div class='cell' data-label='Model'>${link.model}</div>` +
+            `<div class='cell' align='right' data-label='Distance'>${Math.round(convertDistance(link.distance))}${distanceLabel()}</div>` +
+            `<div class='cell' align='right' data-label='Cap (Freq)'>${link.totalCapacity}(${link.frequency})</div>` +
+            `<div class='cell' align='right' data-label='Quality'>${quality}</div>` +
+            `<div class='cell${avgClass}' align='right' data-label='Load Factor'>${link.displayLoadFactor}%</div>` +
+            `<div class='cell${avgClass}' align='right' data-label='Satisfaction'>${Math.round(link.displaySatisfaction * 100)}%</div>` +
+            `<div class='cell${avgClass}' align='right' data-label='Revenue'>$${commaSeparateNumber(link.revenue)}</div>` +
+            `<div class='cell${avgClass}' align='right' data-label='Profit'>$${commaSeparateNumber(link.displayProfit)}</div>` +
+            `<div class='cell${avgClass}' align='right' data-label='Margin'>${(link.displayProfitMargin * 100).toFixed(2)}%</div>` +
+            `<div class='cell' align='right' data-label='Staff'>${link.currentStaffRequired}</div>` +
+            `<div class='cell' align='right' data-label='Profit / Staff'>$${commaSeparateNumber(link.profitPerStaff)}</div>` +
             `</div>`
         );
     });

--- a/airline-web/public/stylesheets/mobile.css
+++ b/airline-web/public/stylesheets/mobile.css
@@ -8,6 +8,27 @@
         overflow: scroll !important;
     }
 
+    /* Flights list: the wide multi-column table is unreadable on a phone (columns run
+       off-screen). Render each flight as a stacked "label: value" card instead. Cells
+       carry a data-label set in updateLinksTable (airline.js). */
+    #linksCanvas .table.data { display: block; min-width: 0 !important; height: auto; }
+    #linksCanvas .table.data .table-header { display: none; }
+    #linksCanvas .table.data .table-row {
+        display: block; height: auto;
+        border: 1px solid rgba(0, 0, 0, 0.15); border-radius: 10px;
+        margin: 10px 6px; padding: 8px 12px; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    }
+    #linksCanvas .table.data .table-row .cell {
+        display: block !important; width: auto !important; height: auto;
+        text-align: left !important; padding: 3px 0 !important; border: none !important;
+        white-space: normal !important;
+    }
+    #linksCanvas .table.data .table-row .cell[data-label]::before {
+        content: attr(data-label) ": "; font-weight: 700; opacity: 0.55;
+    }
+    #linksCanvas .table.data .table-row .cell:first-child { display: none !important; } /* checkbox */
+    #linksCanvas .table.data .table-row .cell[data-label="From"]::before { content: "\2708 From: "; }
+
     div.section, .modal-content {
         padding: 8px;
     }


### PR DESCRIPTION
Second UI pass. The flights table has 13 columns — on a phone it ran off-screen with revenue/load-factor hidden and no scroll hint. On mobile, each flight now renders as a stacked **"label: value" card** (From→To, Model, Distance, Cap(Freq), Q, LF, SF, Revenue, Profit, Margin, Staff, $/Staff).

- `updateLinksTable` (airline.js): each row cell tagged with `data-label`.
- `mobile.css`: inside the existing phone media query, `#linksCanvas`'s table becomes block cards via `cell::before { content: attr(data-label) }`.

Desktop unchanged (rules scoped to the mobile media query). Verified via Playwright on an iPhone viewport — every flight fully readable, no horizontal scroll. Same pattern can extend to `/country` next.