### PR TITLE
fix(web): readable wide data tables on mobile

### DIFF
--- a/airline-web/public/stylesheets/mobile.css
+++ b/airline-web/public/stylesheets/mobile.css
@@ -178,6 +178,27 @@
         overflow-x: scroll;
     }
 
+    /* Wide multi-column data tables (outstanding loans, alliance/champions rankings,
+       country list, olympics, ...) shrink their fixed % column widths on a phone until
+       the values collide or the right-most columns get clipped off-screen. Drop the
+       inline widths, let cells wrap, and shrink the font so every column stays readable
+       within the viewport. The flights list opts out via its more-specific
+       #linksCanvas card rules above. */
+    .table.data .cell {
+        width: auto !important;
+        min-width: 0 !important;
+        white-space: normal !important;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+        font-size: 10px;
+        padding-left: 2px;
+        padding-right: 2px;
+    }
+    .table.data .table-header .cell {
+        font-size: 9px;
+        line-height: 1.05;
+    }
+
     .sheet .table.data {
         padding: 4px;
     }


### PR DESCRIPTION
## Problem
Several pages use `.table.data` cells with fixed `%` column widths. On a phone (390px) those shrink until content collides or clips:

- **/bank/ Outstanding Loans** — money values literally overlapped, unreadable (e.g. `$50,0007,719,0557%...`)
- **/alliance/ & /champions/ rankings** — right-most columns (Tourist Pax, Prestige) clipped off-screen and unreachable (canvas is `overflow-x:hidden`)
- **/country/** — "Openness" column + values clipped
- **/olympics/** — "Remaining Duration" header truncated

## Fix
One mobile-only CSS rule: drop the inline `%` widths on `.table.data .cell`, allow wrapping (`word-break`/`overflow-wrap`), and shrink the font (10px body / 9px header) so every column stays within the viewport. CSS-only, no markup/JS change.

The flights list is unaffected — its card layout wins via the more-specific `#linksCanvas` rules.

## Verification
Prototyped live via Playwright `addStyleTag` on iPhone 13 viewport before committing. After the fix: bank loans fully readable, alliance shows all 6 columns, country shows Openness, olympics header/status wrap cleanly. No regression to flights cards or the 3-column aircraft market table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)