### PR TITLE
revert(web): flights list as table on mobile, not cards

### DIFF
--- a/airline-web/public/stylesheets/mobile.css
+++ b/airline-web/public/stylesheets/mobile.css
@@ -8,30 +8,6 @@
         overflow: scroll !important;
     }
 
-    /* Flights list: the wide multi-column table is unreadable on a phone (columns run
-       off-screen). Render each flight as a stacked "label: value" card instead. Cells
-       carry a data-label set in updateLinksTable (airline.js). */
-    #linksCanvas .table.data { display: block; min-width: 0 !important; height: auto; }
-    #linksCanvas .table.data .table-header { display: none; }
-    #linksCanvas .table.data .table-row {
-        display: block; height: auto;
-        border: 1px solid rgba(0, 0, 0, 0.15); border-radius: 10px;
-        margin: 10px 6px; padding: 8px 12px; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
-    }
-    #linksCanvas .table.data .table-row .cell {
-        display: block !important; width: auto !important; height: auto;
-        text-align: left !important; padding: 3px 0 !important; border: none !important;
-        white-space: normal !important;
-        /* Force the theme text colour: the desktop table gives highlighted rows white
-           text, which is invisible on a card. */
-        color: var(--text-color) !important;
-    }
-    #linksCanvas .table.data .table-row .cell[data-label]::before {
-        content: attr(data-label) ": "; font-weight: 700; opacity: 0.55;
-    }
-    #linksCanvas .table.data .table-row .cell:first-child { display: none !important; } /* checkbox */
-    #linksCanvas .table.data .table-row .cell[data-label="From"]::before { content: "\2708 From: "; }
-
     div.section, .modal-content {
         padding: 8px;
     }


### PR DESCRIPTION
## Why
User feedback: the mobile card layout for the flights/routes list is harder to scan than the table. They prefer the table.

## Change
Remove the `#linksCanvas` card-view overrides from mobile.css. With the generic mobile data-table rule (PR #59) now wrapping cells and shrinking the font to fit a 390px viewport, the flights table renders cleanly as a table — consistent with every other page. CSS-only.

The `data-label` attributes added to cells in airline.js (PR #57) are now unused but harmless; left in place to avoid an unnecessary change.

## Verification
Prototyped live on iPhone 13 viewport: table fits within the viewport (scrollWidth 380 ≤ 390, no horizontal overflow), all rows + columns present and readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)