### PR TITLE
fix(web): cap alliance/rivals chart height on mobile

### DIFF
--- a/airline-web/public/stylesheets/mobile.css
+++ b/airline-web/public/stylesheets/mobile.css
@@ -175,6 +175,21 @@
         line-height: 1.05;
     }
 
+    /* The alliance/rivals charts reserve 480px / 360px (inline min-height) which, on a
+       short phone screen, pushes the ranking table and detail panel far below a mostly-
+       empty chart. Cap them so the data below is reachable without a long scroll. The
+       CSS is present at first paint, so Chart.js sizes the canvas to the smaller box on
+       creation. */
+    #allianceChartContainer {
+        flex: none !important;
+        min-height: 0 !important;
+        height: 240px !important;
+    }
+    #rivalsChartContainer {
+        min-height: 0 !important;
+        height: 260px !important;
+    }
+
     .sheet .table.data {
         padding: 4px;
     }


### PR DESCRIPTION
## Problem
On a phone, `/alliance/` reserves **480px** and `/rivals/` **360px** of vertical space for their chart (inline `min-height`). On a ~660px screen that pushes the ranking table — and the alliance detail panel (status, role, members) — far below a chart that is often mostly empty, requiring a long scroll to reach the actual data.

## Fix
Mobile-only CSS caps the chart containers to 240px (alliance) / 260px (rivals) and drops alliance `flex:1` so it stops growing to fill. The rule is present at first paint, so Chart.js (`maintainAspectRatio:false`) sizes the canvas to the smaller box on creation. CSS-only, no template recompile.

## Verification
Prototyped live on iPhone 13 viewport: alliance chart shrinks to 240px with the ranking table + "Atmos Air" detail panel now visible above the fold; rivals chart shrinks to 260px with the full rivals table (all columns) visible right below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)