### PR TITLE
fix(web): hangar plane overlays tappable on mobile

### DIFF
--- a/airline-web/public/stylesheets/mobile.css
+++ b/airline-web/public/stylesheets/mobile.css
@@ -190,6 +190,27 @@
         height: 260px !important;
     }
 
+    /* Hangar / aircraft market: the right group (Aircraft Cost Calculator + selected-
+       model details) is a .sidePanel, so the generic mobile rule pins it absolute at
+       75dvh where it overlays the lower half of the plane list and blocks taps on those
+       planes' maintenance / usage overlays. Lay the canvas out as one natural-scrolling
+       column instead: tabs -> full plane list -> cost calculator -> model details. */
+    #airplaneCanvas {
+        display: block !important;
+        height: auto !important;
+    }
+    #airplaneCanvas .airplaneCanvasLeftGroup {
+        height: auto !important;
+        overflow: visible !important;
+    }
+    #airplaneCanvas .airplaneCanvasRightGroup {
+        position: static !important;
+        top: auto !important;
+        left: auto !important;
+        width: 100% !important;
+        height: auto !important;
+    }
+
     .sheet .table.data {
         padding: 4px;
     }


### PR DESCRIPTION
## Problem
Reported: on mobile you cant scroll down to tap the maintenance / usage / capacity overlays on planes lower in the hangar list — the Aircraft Cost Calculator blocks them.

Confirmed via Playwright: the hangar right group (`.airplaneCanvasRightGroup`) carries the `.sidePanel` class, so the generic mobile rule pins it `position:absolute; top:75dvh`. It overlays the lower half of the plane list (height ~1264px starting at y≈498) and intercepts taps. The diagnostic showed plane sections below the fold returning `BLOCKED` from `elementFromPoint`.

## Fix
Scoped to `#airplaneCanvas`, lay the canvas out as one natural-scrolling column on mobile: tabs → full plane list → cost calculator → model details. The left group grows to its content (`height:auto; overflow:visible`) and the right group flows normally (`position:static`) below it. CSS-only, no template recompile.

The map slide-up panels (`.mapOverlayPanel`) and all other `.sidePanel` users are untouched.

## Verification
Prototyped live on iPhone 13 viewport. Before: 1+ plane sections `BLOCKED`. After: **0/12 blocked**, cost calculator relocated below the plane list (y≈711), every plane reachable and tappable. Map `#sidePanel` confirmed still `absolute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)