### PR TITLE
fix(web): stop hangar cost calculator leaking onto other pages

### DIFF
--- a/airline-web/public/stylesheets/mobile.css
+++ b/airline-web/public/stylesheets/mobile.css
@@ -194,8 +194,12 @@
        model details) is a .sidePanel, so the generic mobile rule pins it absolute at
        75dvh where it overlays the lower half of the plane list and blocks taps on those
        planes' maintenance / usage overlays. Lay the canvas out as one natural-scrolling
-       column instead: tabs -> full plane list -> cost calculator -> model details. */
-    #airplaneCanvas {
+       column instead: tabs -> full plane list -> cost calculator -> model details.
+       Scoped to .active so the canvas (and its cost calculator) is only forced visible
+       when the hangar/market is actually open - otherwise display:block would override
+       the display:none the SPA sets when navigating away, leaking the cost calculator
+       onto every other page (e.g. the flights route detail). */
+    #airplaneCanvas.active {
         display: block !important;
         height: auto !important;
     }


### PR DESCRIPTION
## Regression
PR #62 (hangar overlay fix) forced `#airplaneCanvas { display:block !important }` on mobile. The SPA hides inactive canvases with an inline `display:none`, which the `!important` rule overrode — so the airplane canvas and its **Aircraft Cost Calculator** stayed visible on every page, overlaying e.g. the flights route-detail panel when tapping a route. Reported by user.

## Fix
Scope the rule to `#airplaneCanvas.active`. The column layout only applies while the hangar/market is open; navigating away removes `.active` and the inline `display:none` hides it. CSS-only.

## Verification — 14-page mobile e2e sweep
Added `e2e/ui-e2e-mobile.mjs` (not committed; local harness). With this fix injected on an iPhone 13 viewport: **58 passed, 2 failed**, where the only 2 failures are a pre-existing unrelated edge (bare `/airport/` with no IATA throws `toUpperCase` on null — reached normally via a map click, not a menu). Specifically validated:
- Exactly one expected canvas visible per page (no foreign-canvas leak)
- Flights route click → detail opens, **cost calculator not present**
- Hangar planes still tappable (0 blocked), plane detail overlay opens
- No horizontal overflow on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)