### PR TITLE
fix(web): bare/unknown /airport/ redirects to map instead of crashing

### DIFF
--- a/airline-web/public/javascripts/routes.js
+++ b/airline-web/public/javascripts/routes.js
@@ -121,9 +121,13 @@ function initializeRoutes() {
     page('/airport/:iata?', async (ctx) => {
         backgroundLoad();
         const iata = ctx.params.iata ?? null;
-        document.title = iata ? `${iata.toUpperCase()} Airport` : 'Airport';
-        id = getAirportByAttribute(iata.toUpperCase(), 'iata').id || null;
-        showAirportDetails(id);
+        // The airport view needs an airport. Reached via a map click; a bare or unknown
+        // /airport/ has nothing to show (and iata.toUpperCase() would throw on null), so
+        // send the user to the map to pick one instead of crashing.
+        const airport = iata ? getAirportByAttribute(iata.toUpperCase(), 'iata') : null;
+        if (!airport) { page.redirect('/map/'); return; }
+        document.title = `${iata.toUpperCase()} Airport`;
+        showAirportDetails(airport.id);
     });
 
     page('/flights/:link?', (ctx) => {


### PR DESCRIPTION
## Problem
`page('/airport/:iata?')` called `iata.toUpperCase()` and `.id` unconditionally. Visiting `/airport/` with no airport code (or an unknown one) threw `Cannot read properties of null (reading 'toUpperCase')` and left a blank/wrong canvas. Surfaced by the mobile e2e sweep.

## Fix
Look up the airport only when an IATA is present; if there is no matching airport, `page.redirect('/map/')` so the user can pick one. The airport view is reached by tapping the map, so this is the natural fallback. JS-only.

## Verification
Re-running `e2e/ui-e2e-mobile.mjs` against the deploy should take it to 60/60 (the prior 2 failures were exactly this crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)