### PR TITLE
fix(web): mobile layout on Firefox Android (viewport width vs device-width)

### DIFF
--- a/airline-web/public/javascripts/main.js
+++ b/airline-web/public/javascripts/main.js
@@ -296,6 +296,16 @@ function showWorldMap() {
     removeTempPath();
 	setActiveDiv($('#worldMapCanvas'));
 	$('#sidePanel').appendTo($('#worldMapCanvas'))
+	// The map is background-loaded, so its GL canvas can be created while the container
+	// is hidden/short. On mobile browsers whose viewport changes as the URL bar shows or
+	// hides, the canvas can stay at that stale size, leaving dead space below the map.
+	// Nudge a resize now that the container is visible at its full height (and once more
+	// after the fade settles) so the canvas always fills it.
+	if (window.AirlineMap && window.AirlineMap.map) {
+		const resizeMap = () => { try { window.AirlineMap.map.resize(); } catch (e) {} };
+		requestAnimationFrame(resizeMap);
+		setTimeout(resizeMap, 450);
+	}
 	if (selectedLink) {
 		selectLinkFromMap(selectedLink, !activeAirportPopupInfoWindow) //do not refocus if there's a popup, stay where it is
 	}

--- a/airline-web/public/stylesheets/main.css
+++ b/airline-web/public/stylesheets/main.css
@@ -473,7 +473,7 @@ li.row, div.table-row {
     position: relative;
 }
 
-@media only screen and (min-device-width: 800px) {
+@media only screen and (min-width: 800px) {
     #airplaneModelTableFilters {
         position: absolute;
         top: 0px;
@@ -957,7 +957,7 @@ li.row, div.table-row {
     align-items: flex-start;
     gap: 1px;
 }
-@media only screen and (max-device-width : 640px) {
+@media only screen and (max-width : 640px) {
     .item-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
@@ -2687,7 +2687,7 @@ i, .italic {
     box-sizing: border-box;
     margin: 0 auto;
 }
-@media only screen and (max-device-width: 640px) {
+@media only screen and (max-width: 640px) {
 .flex-container-width-half > div {
         width: 100% !important;
     }
@@ -2756,7 +2756,7 @@ i, .italic {
 }
 
 /* Fullscreen Map */
-@media only screen and (min-device-width : 640px) {
+@media only screen and (min-width : 640px) {
     #hideRivalMapButton {
         top: 48px !important;
     }

--- a/airline-web/public/stylesheets/mobile.css
+++ b/airline-web/public/stylesheets/mobile.css
@@ -1,5 +1,5 @@
 /* mobile (portrait) ----------- */
-@media only screen and (max-device-width : 640px) {
+@media only screen and (max-width : 640px) {
     .mainPanel, #map {
         height: calc(100dvh - 34px);
         width: 100%;

--- a/airline-web/public/stylesheets/new-style.css
+++ b/airline-web/public/stylesheets/new-style.css
@@ -83,7 +83,7 @@ li:before {
 
 /* mobile (portrait) ----------- */
 @media only screen
-and (max-device-width : 1024px)
+and (max-width : 1024px)
 and (orientation : portrait) {
     .frost-section {
         font-size: 1em;


### PR DESCRIPTION
## Root cause (Firefox Android)
Reported: on mobile the map looks messy — desktop top bar (sim controls + a vertical reputation-star stack overflowing the oil price) and a large dead zone below the map. Persists across refresh/rotate. User is on **Firefox** for Android.

The mobile/desktop breakpoints were keyed off the **deprecated `device-width`** media feature. `device-width` reflects the physical screen, which **Firefox for Android reports in physical pixels (~1080)**. So on Firefox:
- `max-device-width:640` (all of mobile.css + 2 main.css blocks) was **skipped**
- `min-device-width:640` / `min-device-width:800` (desktop blocks) all **matched**

→ the phone rendered the full desktop layout: desktop top bar, `#linksCanvas .mainPanel { width:50% }`, desktop `#map` height that doesn’t fill a tall phone (the dead space), etc. Chromium reports `device-width` in CSS px, so it looked fine there — which is why my earlier Chromium-based Playwright captures all passed.

## Fix
Convert every breakpoint to viewport-relative `width` (`max-width`/`min-width`) — the modern, consistent equivalent. At ≤640px **viewport** the mobile rules apply; above, desktop. Identical to intent on a maximised desktop and on real phones, but now correct on Firefox/any browser regardless of how it reports screen size. Also nudge a MapLibre `resize()` on map show (it’s background-loaded, so the canvas can be created stale).

6 queries: mobile.css (1), main.css (3: max 640, min 640, min 800), new-style.css (1: 1024 portrait), + main.js resize.

## Verification
- Confirmed in Playwright (Chromium **and** Firefox engines) that at a 412px viewport `max-width:640` matches and mobile styles apply (desktopOnly hidden) — no regression.
- `device-width` is deprecated specifically because it keys off screen size; this is the recommended migration.
- Will re-run the 14-page mobile e2e sweep + a desktop-width check against the deploy.

Note: only the user’s Firefox Android device can fully confirm the visual fix (Playwright forces screen=viewport so it can’t replicate Firefox’s physical-px screen.width); shipping for on-device verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)