### PR TITLE
feat(data): world news feed foundation + AI-drop events

### DIFF
--- a/airline-data/src/main/scala/com/patson/ComputerAirlineSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/ComputerAirlineSimulation.scala
@@ -22,6 +22,10 @@ object ComputerAirlineSimulation {
       val npcAirlines = AirlineSource.loadAirlinesByCriteria(List(("airline_type", NonPlayerAirline.id)))
       if (npcAirlines.isEmpty) return
 
+      // Resolve the player airlines once so each drop can be reported to the news feed
+      // (no-op / empty unless solo.news.enabled).
+      val playerIds = WorldNews.playerAirlineIds()
+
       // Act on a rotating, bounded subset each cycle to keep the cost small.
       val perCycle = Math.max(1, SoloConfig.aiAirlinesPerCycle)
       val sorted = npcAirlines.sortBy(_.id)
@@ -35,11 +39,13 @@ object ComputerAirlineSimulation {
           // links whose cumulative profit is below the (negative) threshold.
           val consumptions = LinkSource.loadLinkConsumptionsByAirline(airline.id, SoloConfig.aiLossLookbackCycles)
           if (consumptions.nonEmpty) {
-            val profitByLink = consumptions.groupBy(_.link.id).map { case (linkId, list) => (linkId, list.map(_.profit.toLong).sum) }
+            // Keep a representative link per id so the news feed can name the route.
+            val profitByLink = consumptions.groupBy(_.link.id).map { case (linkId, list) => (linkId, list.map(_.profit.toLong).sum, list.head.link) }
             val losers = profitByLink.filter(_._2 < SoloConfig.aiDropProfitThreshold).toList.sortBy(_._2)
-            losers.take(Math.max(0, SoloConfig.aiMaxDropsPerAirline)).foreach { case (linkId, totalProfit) =>
+            losers.take(Math.max(0, SoloConfig.aiMaxDropsPerAirline)).foreach { case (linkId, totalProfit, link) =>
               LinkSource.deleteLink(linkId)
               totalDrops += 1
+              WorldNews.post(playerIds, s"${airline.name} dropped its ${link.from.iata}-${link.to.iata} route", cycle, Some(s"rival_${airline.id}"))
               println(s"[ai] ${airline.name} dropped losing link $linkId (profit $totalProfit over ${SoloConfig.aiLossLookbackCycles} cycles)")
             }
           }

--- a/airline-data/src/main/scala/com/patson/WorldNews.scala
+++ b/airline-data/src/main/scala/com/patson/WorldNews.scala
@@ -1,0 +1,37 @@
+package com.patson
+
+import com.patson.data.{AirlineSource, NotificationSource, SoloConfig}
+import com.patson.model.{Notification, NotificationCategory, NonPlayerAirline}
+
+/**
+  * World news feed (single-player). A thin helper that records ambient world events
+  * (NPC route changes, etc.) as WORLD_NEWS notifications — one row per player airline so
+  * each keeps its own read state — to be browsed in a dedicated News panel, separate from
+  * the personal notification bell.
+  *
+  * No-op unless solo.news.enabled, so default/multiplayer deploys are byte-identical.
+  * Reuses the existing notification store (no schema change); it is subject to the normal
+  * 100-row retention purge, which is fine for a rolling feed.
+  */
+object WorldNews {
+  /**
+    * Player airlines (everything that isn't a computer-controlled carrier). Cheap — the
+    * airline table is on the order of tens of rows. Returns Nil when the feed is off so
+    * callers pay nothing in default deploys.
+    */
+  def playerAirlineIds() : List[Int] =
+    if (!SoloConfig.newsEnabled) Nil
+    else AirlineSource.loadAllAirlines(false).filterNot(_.airlineType == NonPlayerAirline).map(_.id)
+
+  /**
+    * Post one news item, visible to each given player airline. Pass the ids from
+    * playerAirlineIds() (resolve once per cycle and reuse across many posts).
+    */
+  def post(playerAirlineIds : Seq[Int], message : String, cycle : Int, targetId : Option[String] = None) : Unit = {
+    if (!SoloConfig.newsEnabled || playerAirlineIds.isEmpty) return
+    val items = playerAirlineIds.map { id =>
+      Notification(airlineId = id, category = NotificationCategory.WORLD_NEWS, message = message, cycle = cycle, targetId = targetId)
+    }.toList
+    NotificationSource.insertNotificationsBulk(items)
+  }
+}

--- a/airline-data/src/main/scala/com/patson/data/NotificationSource.scala
+++ b/airline-data/src/main/scala/com/patson/data/NotificationSource.scala
@@ -111,6 +111,30 @@ object NotificationSource {
     }
   }
 
+  // Most recent notifications for one airline in a single category (e.g. the WORLD_NEWS
+  // feed, rendered in its own News panel rather than the personal bell).
+  def loadByCategory(airlineId: Int, category: NotificationCategory.Value, limit: Int = 50): List[Notification] = {
+    val connection = Meta.getConnection()
+    try {
+      val statement = connection.prepareStatement(
+        s"SELECT * FROM $NOTIFICATION_TABLE WHERE airline = ? AND category = ? ORDER BY id DESC LIMIT ?"
+      )
+      try {
+        statement.setInt(1, airlineId)
+        statement.setString(2, category.toString)
+        statement.setInt(3, limit)
+        val rs = statement.executeQuery()
+        val result = scala.collection.mutable.ListBuffer[Notification]()
+        while (rs.next()) result += rowToNotification(rs)
+        result.toList
+      } finally {
+        statement.close()
+      }
+    } finally {
+      connection.close()
+    }
+  }
+
   def loadAllByCategory(category: NotificationCategory.Value): List[Notification] = {
     val connection = Meta.getConnection()
     try {
@@ -179,8 +203,10 @@ object NotificationSource {
   def countUnreadByAirline(airlineId: Int): Int = {
     val connection = Meta.getConnection()
     try {
+      // WORLD_NEWS lives in its own pull-based News panel, so it must not drive the
+      // personal notification bell badge (otherwise the feed would constantly nag).
       val statement = connection.prepareStatement(
-        s"SELECT COUNT(*) FROM $NOTIFICATION_TABLE WHERE airline = ? AND is_read = 0"
+        s"SELECT COUNT(*) FROM $NOTIFICATION_TABLE WHERE airline = ? AND is_read = 0 AND category != '${NotificationCategory.WORLD_NEWS}'"
       )
       try {
         statement.setInt(1, airlineId)

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -59,6 +59,13 @@ object SoloConfig {
   val aiLossLookbackCycles : Int = intAt("solo.ai.lossLookbackCycles", 4)
   val aiDropProfitThreshold : Long = longAt("solo.ai.dropProfitThreshold", -500000L)
 
+  // World news feed (single-player): an ambient, pull-based log of notable world
+  // events (NPC route changes, etc.) surfaced in a dedicated News panel, separate from
+  // the personal notification bell. Off by default. Reuses the notification store under
+  // a WORLD_NEWS category (no schema change); events only emit when both this and the
+  // relevant source (e.g. solo.ai.enabled) are on.
+  val newsEnabled : Boolean = boolAt("solo.news.enabled", false)
+
   // Solo progression (Phase G): surface the already-computed milestone system to the
   // player as one-time achievement notifications + a progress view. Off by default so
   // multiplayer/default deploys are unchanged (no notifications, no behavior change).

--- a/airline-data/src/main/scala/com/patson/model/Notification.scala
+++ b/airline-data/src/main/scala/com/patson/model/Notification.scala
@@ -56,6 +56,12 @@ object NotificationCategory extends Enumeration {
    *   the player airline crossed a milestone tier (AirlineMilestones). One per tier, ever.
    *   targetId: "milestone_{name}_{threshold}"; exempt from the retention purge so the
    *   achievement record persists.
+   *
+   * WORLD_NEWS — Single-player world news feed (gated by solo.news.enabled): an ambient
+   *   log of notable world events (NPC route changes, etc.), one row per player airline so
+   *   each keeps its own read state. Surfaced in a dedicated News panel, NOT the personal
+   *   bell — excluded from the bell unread count so it never nags. targetId optional, e.g.
+   *   "rival_{airlineId}" for navigation. Subject to the normal retention purge.
    */
-  val NEGOTIATION_LOSS, LEVEL_UP, LOYALIST, GAME_OVER, OLYMPICS_PRIZE, TUTORIAL, LINK_CANCELLATION, CASH_FLOW_WARNING, PROFIT_MILESTONE, MILESTONE_ACHIEVED = Value
+  val NEGOTIATION_LOSS, LEVEL_UP, LOYALIST, GAME_OVER, OLYMPICS_PRIZE, TUTORIAL, LINK_CANCELLATION, CASH_FLOW_WARNING, PROFIT_MILESTONE, MILESTONE_ACHIEVED, WORLD_NEWS = Value
 }


### PR DESCRIPTION
First slice of the single-player **World News feed** — an ambient, pull-based log of world events for a dedicated News panel (UI in the follow-up PR), separate from the personal notification bell.

- `solo.news.enabled` (default off → inert in default/multiplayer deploys)
- `WORLD_NEWS` notification category, reusing the notification store (**no schema migration**)
- `NotificationSource.loadByCategory(...)` for the feed; WORLD_NEWS **excluded from the bell unread count** so it never nags
- `WorldNews.post(...)` helper — one row per player airline (own read state), no-op unless the flag is on
- `ComputerAirlineSimulation` reports each NPC route drop to the feed ("Rats RDU dropped its RDU-BNA route")

Compile-gated green on the OptiPlex runner before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)