### PR TITLE
feat(web): World News page + enable the feed

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -39,6 +39,7 @@ jobs:
             -Dsolo.bankruptcy.assetsThreshold=-150000000
             -Dsolo.notify.enabled=true
             -Dsolo.ai.enabled=true
+            -Dsolo.news.enabled=true
             -Dsolo.demand.memoize=true
             -Dsolo.progression.enabled=true
             -Dsolo.alliance.minMembers=2

--- a/airline-web/app/controllers/NotificationApplication.scala
+++ b/airline-web/app/controllers/NotificationApplication.scala
@@ -23,7 +23,19 @@ class NotificationApplication @Inject()(cc: ControllerComponents) extends Abstra
 
   def getNotifications(airlineId: Int) = AuthenticatedAirline(airlineId) { _ =>
     NotificationSource.purgeExpiredByCategory(airlineId, NotificationCategory.NEGOTIATION_LOSS, CycleSource.loadCycle())
-    Ok(Json.toJson(NotificationSource.loadNotificationsByAirline(airlineId)))
+    // WORLD_NEWS has its own News panel; keep it out of the personal bell drawer.
+    val personal = NotificationSource.loadNotificationsByAirline(airlineId).filterNot(_.category == NotificationCategory.WORLD_NEWS)
+    Ok(Json.toJson(personal))
+  }
+
+  // World news feed (pull-based, separate from the personal bell).
+  def getNews(airlineId: Int) = AuthenticatedAirline(airlineId) { _ =>
+    Ok(Json.toJson(NotificationSource.loadByCategory(airlineId, NotificationCategory.WORLD_NEWS, 50)))
+  }
+
+  def markNewsRead(airlineId: Int) = AuthenticatedAirline(airlineId) { _ =>
+    NotificationSource.markCategoryRead(airlineId, NotificationCategory.WORLD_NEWS)
+    Ok(Json.obj())
   }
 
   def getUnreadCount(airlineId: Int) = AuthenticatedAirline(airlineId) { _ =>

--- a/airline-web/app/views/fragments/news_canvas.scala.html
+++ b/airline-web/app/views/fragments/news_canvas.scala.html
@@ -1,0 +1,12 @@
+				<div id="newsCanvas" class="canvas" style="height: 100%; display: none;">
+					<div class="mainPanel">
+						<div class="section">
+							<div class="flex-row flex-align-center" style="justify-content: space-between;">
+								<h2>World News</h2>
+								<span class="clickable label" id="newsMarkReadLink">Mark all read</span>
+							</div>
+							<p class="remarks">Notable goings-on across the world &mdash; rival route changes and other events as they happen.</p>
+							<div id="newsList" class="notification-drawer-list" style="margin-top: 8px;"></div>
+						</div>
+					</div>
+				</div>

--- a/airline-web/app/views/fragments/sidebar.scala.html
+++ b/airline-web/app/views/fragments/sidebar.scala.html
@@ -52,6 +52,10 @@
                 <img src='@routes.Assets.versioned("/images/icons/olympics-medal.png")'>
                 <span class="label floatLabel">Olympics</span>
             </a>
+            <a class="nav-link" data-link="news" href="/news/">
+                <img src='@routes.Assets.versioned("/images/icons/megaphone.png")'>
+                <span class="label floatLabel">News</span>
+            </a>
             <a class="nav-link" data-link="search" href="/search/">
                 <img src='@routes.Assets.versioned("/images/icons/magnifier.png")'>
                 <span class="label floatLabel">Search</span>

--- a/airline-web/app/views/index.scala.html
+++ b/airline-web/app/views/index.scala.html
@@ -31,6 +31,7 @@
             @fragments.alliance_canvas()
             @fragments.log_canvas()
             @fragments.event_canvas()
+            @fragments.news_canvas()
         </div>
         <!-- main canvas end -->
     </div> <!-- end container for main canvas and the landing blur -->

--- a/airline-web/conf/routes
+++ b/airline-web/conf/routes
@@ -314,4 +314,5 @@ GET     /log/                           controllers.Application.index(path = "/"
 GET     /log/*path                      controllers.Application.index(path)
 GET     /olympics/                      controllers.Application.index(path = "/")
 GET     /olympics/*path                 controllers.Application.index(path)
+GET     /news/                          controllers.Application.index(path = "/")
 GET		/							    controllers.Application.index(path = "/")

--- a/airline-web/conf/routes
+++ b/airline-web/conf/routes
@@ -120,6 +120,8 @@ POST		 /airlines/:airlineId/sign-oil-contract	controllers.OilApplication.signCon
 DELETE	 /airlines/:airlineId/oil-contracts/:contractId	controllers.OilApplication.terminateContract(airlineId : Int, contractId : Int)
 GET	 	 /airlines/:airlineId/oil-inventory-options		controllers.OilApplication.getInventoryOptions(airlineId : Int)
 POST		 /airlines/:airlineId/set-oil-inventory-option  controllers.OilApplication.setInventoryOption(airlineId : Int, optionId : Int)
+GET		 /airlines/:airlineId/news  controllers.NotificationApplication.getNews(airlineId : Int)
+POST	 /airlines/:airlineId/news/read  controllers.NotificationApplication.markNewsRead(airlineId : Int)
 GET		 /airlines/:airlineId/notifications  controllers.NotificationApplication.getNotifications(airlineId : Int)
 GET		 /airlines/:airlineId/notifications/unread  controllers.NotificationApplication.getUnreadCount(airlineId : Int)
 POST	 /airlines/:airlineId/notifications/read  controllers.NotificationApplication.markAllRead(airlineId : Int)

--- a/airline-web/public/javascripts/notification.js
+++ b/airline-web/public/javascripts/notification.js
@@ -153,8 +153,81 @@ function getCategoryIcon(category) {
         case 'CASH_FLOW_WARNING':
         case 'LINK_CANCELLATION': return '⚠'
         case 'PROFIT_MILESTONE': return '$'
+        case 'WORLD_NEWS': return '📣'
         default: return '•'
     }
+}
+
+/* ---------------- World News feed (pull-based; separate from the bell) ---------------- */
+
+function showNewsCanvas() {
+    setActiveDiv($('#newsCanvas'))
+    loadNews()
+    $('#newsMarkReadLink').off('click.news').on('click.news', function(e) {
+        e.stopPropagation()
+        markAllNewsRead()
+    })
+}
+
+function loadNews() {
+    if (!activeAirline) return
+    var $list = $('#newsList')
+    $list.empty()
+    $.ajax({
+        type: 'GET',
+        url: '/airlines/' + activeAirline.id + '/news',
+        dataType: 'json',
+        success: function(items) {
+            if (!items || items.length === 0) {
+                $list.append('<div class="notification-empty">No news yet</div>')
+                return
+            }
+            $.each(items, function(i, n) {
+                var $item = $('<div class="notification-item"></div>')
+                if (!n.isRead) $item.addClass('unread')
+                $item.append('<span class="notification-icon">' + getCategoryIcon(n.category) + '</span>')
+                $item.append('<span class="notification-message">' + htmlEncode(n.message) + '</span>')
+                if (typeof currentCycle !== 'undefined' && currentCycle && n.cycle) {
+                    var weeks = Math.max(0, currentCycle - n.cycle)
+                    var age = weeks === 0 ? 'this week' : (weeks + (weeks === 1 ? ' week ago' : ' weeks ago'))
+                    $item.append('<span class="notification-age label" style="opacity:0.5; margin-left:auto; padding-left:8px; white-space:nowrap;">' + age + '</span>')
+                }
+                if (n.targetId) {
+                    $item.addClass('clickable')
+                    ;(function(targetId) {
+                        $item.on('click', function() {
+                            var m = /^rival_(\d+)$/.exec(targetId)
+                            if (m) {
+                                navigateTo('/rivals/' + m[1])
+                            } else if (/^\d+-\d+$/.test(targetId)) {
+                                var parts = targetId.split('-')
+                                planLink(parseInt(parts[0]), parseInt(parts[1]))
+                            } else if (/^\d+$/.test(targetId)) {
+                                navigateTo('/flights/' + targetId)
+                            } else {
+                                navigateTo(targetId)
+                            }
+                        })
+                    })(n.targetId)
+                }
+                $list.append($item)
+            })
+        },
+        error: function() {
+            $list.append('<div class="notification-empty">Failed to load news</div>')
+        }
+    })
+}
+
+function markAllNewsRead() {
+    if (!activeAirline) return
+    $.ajax({
+        type: 'POST',
+        url: '/airlines/' + activeAirline.id + '/news/read',
+        success: function() {
+            $('#newsList .notification-item').removeClass('unread')
+        }
+    })
 }
 
 function markNotificationRead(notifId, $item) {

--- a/airline-web/public/javascripts/routes.js
+++ b/airline-web/public/javascripts/routes.js
@@ -240,6 +240,12 @@ function initializeRoutes() {
         showEventCanvas();
     });
 
+    page('/news/', () => {
+        backgroundLoad();
+        document.title = 'News';
+        showNewsCanvas();
+    });
+
     // Start page.js routing
     page.start();
 }


### PR DESCRIPTION
N-2 of the World News feed: the UI, plus enabling it on the OptiPlex instance.

- **News page** in the main menu (megaphone icon) → `/news/` "World News", reusing the notification-item styling; items show icon, message, age, and deep-link to the rival. Reachable on desktop + mobile (hamburger); additive so it cannot regress the notification bell.
- `getNews` / `markNewsRead` endpoints; WORLD_NEWS filtered out of the personal bell drawer.
- Server route for `/news/` so direct-load / refresh serves the SPA shell (in-app nav already worked).
- Deploy: `-Dsolo.news.enabled=true` (NPC drops already flow via `solo.ai.enabled`), so the feed starts populating.

Verified live on the branch deploy: login OK, News page renders ("No news yet" with the flag still off), no JS errors, top bar clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)