### PR TITLE
fix(web): campaign popup on-screen on mobile + /news/ cold-load

### DIFF
--- a/airline-web/public/javascripts/campaign.js
+++ b/airline-web/public/javascripts/campaign.js
@@ -40,6 +40,18 @@ async function showCampaignOverlay(airportId, popupPosition) {
         });
     }
     $panel.show()
+    if (popupPosition) {
+        // Anchoring to the tapped marker can push the popup off-screen (e.g. markers near
+        // the left/bottom edge on a phone). Clamp it fully into the viewport now that it's
+        // shown and measurable.
+        const margin = 8
+        const rect = $panel[0].getBoundingClientRect()
+        const maxLeft = Math.max(margin, window.innerWidth - rect.width - margin)
+        const maxTop = Math.max(margin, window.innerHeight - rect.height - margin)
+        const left = Math.min(Math.max(margin, popupPosition.left - 240), maxLeft)
+        const top = Math.min(Math.max(margin, popupPosition.top), maxTop)
+        $panel.css({ left: `${left}px`, top: `${top}px` })
+    }
 
     try {
         const [managersInfo, campaigns] = await Promise.all([

--- a/airline-web/public/javascripts/routes.js
+++ b/airline-web/public/javascripts/routes.js
@@ -243,7 +243,22 @@ function initializeRoutes() {
     page('/news/', () => {
         backgroundLoad();
         document.title = 'News';
-        showNewsCanvas();
+        // showNewsCanvas lives in the deferred notification.js, which may not be loaded
+        // yet on a cold load / refresh of /news/. Wait for it instead of silently falling
+        // through to the default canvas (the map).
+        if (typeof showNewsCanvas === 'function') {
+            showNewsCanvas();
+        } else {
+            const start = Date.now();
+            const timer = setInterval(() => {
+                if (typeof showNewsCanvas === 'function') {
+                    clearInterval(timer);
+                    showNewsCanvas();
+                } else if (Date.now() - start > 5000) {
+                    clearInterval(timer);
+                }
+            }, 100);
+        }
     });
 
     // Start page.js routing


### PR DESCRIPTION
Two JS-only mobile fixes.

## Campaign popup off-screen (reported)
The airport campaign popup is positioned `fixed` anchored to the tapped marker (`left - 240`, `top`). For markers near the left/bottom edge on a phone it lands off-screen — reproduced at `left:-90, bottom:843` on a 390×664 viewport. Fix: clamp the popup fully into the viewport after it's shown. Verified across left-bottom / far-left / right-top taps — all land `onScreen: true`.

## /news/ cold-load (follow-up #36)
Hard-loading / refreshing `/news/` fell through to the map because `showNewsCanvas` (in the deferred `notification.js`) wasn't loaded when the route fired. Fix: the `/news/` route waits (bounded retry) for `showNewsCanvas` before giving up. In-app navigation already worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)