### PR TITLE
chore(deploy): enable H-1 NPC route opening (solo.ai.growth.enabled)

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -39,6 +39,7 @@ jobs:
             -Dsolo.bankruptcy.assetsThreshold=-150000000
             -Dsolo.notify.enabled=true
             -Dsolo.ai.enabled=true
+            -Dsolo.ai.growth.enabled=true
             -Dsolo.news.enabled=true
             -Dsolo.demand.memoize=true
             -Dsolo.progression.enabled=true


### PR DESCRIPTION
Turns on Phase H-1 live with the conservative SoloConfig defaults (<=1 open/NPC/cycle, only profitable routes, network ceiling 60, genuinely-idle frames only). Code shipped gated-off in #71; this flips the flag in the sim deploy opts. Behavior is bounded and self-limiting; we watch the sim log + News feed for cadence and can tune knobs or revert by removing the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)