### PR TITLE
chore(data): remove H-1 temp diagnostics, revert growth cap to default

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -40,7 +40,6 @@ jobs:
             -Dsolo.notify.enabled=true
             -Dsolo.ai.enabled=true
             -Dsolo.ai.growth.enabled=true
-            -Dsolo.ai.growth.maxAirlinesPerCycle=10
             -Dsolo.news.enabled=true
             -Dsolo.demand.memoize=true
             -Dsolo.progression.enabled=true

--- a/airline-data/src/main/scala/com/patson/ComputerAirlineGrowth.scala
+++ b/airline-data/src/main/scala/com/patson/ComputerAirlineGrowth.scala
@@ -111,7 +111,6 @@ object ComputerAirlineGrowth {
       .map(p => (p, availableMinutes(p)))
       .filter(_._2 >= SoloConfig.aiGrowthMinAvailableMinutes)
       .sortBy(-_._2)
-    println(s"[ai-growth-diag] ${airline.name}: network=$networkSize spares=${spareFrames.size}") // TEMP diagnostic
     if (spareFrames.isEmpty) return 0
 
     // Already-served city pairs (either direction) so we never duplicate a route.
@@ -134,8 +133,6 @@ object ComputerAirlineGrowth {
         }
       }
     }
-    println(s"[ai-growth-diag] ${airline.name} eval=${framesToConsider.size} scored=${scoredAll.size} best=${scoredAll.map(_._2).maxOption.getOrElse(Long.MinValue)} thr=${SoloConfig.aiOpenProfitThreshold}") // TEMP diagnostic
-
     selectBestOpen(networkSize, SoloConfig.aiMaxNetworkSize, scoredAll, SoloConfig.aiOpenProfitThreshold) match {
       case Some(link) =>
         val profit = scoredAll.find(_._1 eq link).map(_._2).getOrElse(0L)


### PR DESCRIPTION
H-1 confirmed working live (NPCs opening profitable routes matched to spare frames — e.g. Flying Cod opened OTP-AMS at +21k/wk, 1 open/cycle cadence). Removes the temporary `[ai-growth-diag]` logging and the `maxAirlinesPerCycle=10` observation override (back to conservative default 3). The per-open `[ai-growth]` event log stays, like the drop log. Compile-gated, 11/11 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)