### PR TITLE
feat(data): living-world AI price tuning (H-2) + enable

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -40,6 +40,7 @@ jobs:
             -Dsolo.notify.enabled=true
             -Dsolo.ai.enabled=true
             -Dsolo.ai.growth.enabled=true
+            -Dsolo.ai.pricetune.enabled=true
             -Dsolo.news.enabled=true
             -Dsolo.demand.memoize=true
             -Dsolo.progression.enabled=true

--- a/airline-data/src/main/scala/com/patson/ComputerAirlinePriceTuning.scala
+++ b/airline-data/src/main/scala/com/patson/ComputerAirlinePriceTuning.scala
@@ -1,0 +1,99 @@
+package com.patson
+
+import com.patson.data.{LinkSource, SoloConfig}
+import com.patson.model._
+
+/**
+  * Phase H-2 of the living-world AI: lets an acting NPC nudge prices on a few of its existing
+  * links toward equilibrium, so competition feels adaptive rather than static — the missing
+  * middle between opening routes (H-1) and dropping them. Deliberately bounded:
+  *
+  *  - only NonPlayerAirline carriers (callers pass the same rotating subset); players untouched.
+  *  - a persistently FULL link (load factor >= high) edges its price UP to capture revenue; a
+  *    persistently EMPTY one (load factor <= low) edges DOWN to fill seats / undercut a rival.
+  *    Between the thresholds, nothing changes.
+  *  - one small step per cycle (default ±5%), clamped to a band around the standard price so
+  *    prices can never run away; at most `maxLinksPerAirline` links touched per airline per cycle.
+  *  - changes existing links only (a targeted price-only DB update) — no fleet/route churn, no
+  *    news spam (price nudges are too granular to surface).
+  *
+  * Gated behind solo.ai.pricetune.enabled (default off) — a no-op otherwise.
+  */
+object ComputerAirlinePriceTuning {
+
+  // ---- Pure decision helpers (no DB), unit-tested in ComputerAirlinePriceTuningSpec ----
+
+  /** Price multiplier for one cycle from recent load factor: up a step when persistently full,
+    * down a step when persistently empty, unchanged in the comfortable middle band. */
+  def priceNudgeFactor(loadFactor : Double, lowLF : Double, highLF : Double, step : Double) : Double = {
+    if (loadFactor >= highLF) 1.0 + step
+    else if (loadFactor <= lowLF) 1.0 - step
+    else 1.0
+  }
+
+  /** Apply the factor to each class price, clamped to [floorRatio, ceilRatio] * standard price so
+    * a price can never run away from the route's fair value over many cycles. */
+  def nudgedPrice(current : LinkClassValues, standard : LinkClassValues, factor : Double, floorRatio : Double, ceilRatio : Double) : LinkClassValues = {
+    def clampClass(cur : Int, std : Int) : Int = {
+      val floor = (std * floorRatio).toInt
+      val ceil = Math.max(floor, (std * ceilRatio).toInt)
+      Math.max(floor, Math.min(ceil, (cur * factor).toInt))
+    }
+    LinkClassValues(clampClass(current.economyVal, standard.economyVal), clampClass(current.businessVal, standard.businessVal), clampClass(current.firstVal, standard.firstVal))
+  }
+
+  /** Tune prices for each acting airline. Returns the number of links adjusted. */
+  def tune(acting : Seq[Airline], cycle : Int) : Int = {
+    if (!SoloConfig.aiPriceTuneEnabled) return 0
+    var adjusted = 0
+    acting.take(Math.max(0, SoloConfig.aiPriceTuneMaxAirlinesPerCycle)).foreach { airline =>
+      try {
+        adjusted += tuneAirline(airline)
+      } catch {
+        case e : Exception => println(s"[ai-pricetune] error processing airline ${airline.id}: ${e.getMessage}")
+      }
+    }
+    adjusted
+  }
+
+  private def tuneAirline(airline : Airline) : Int = {
+    val lookback = Math.max(1, SoloConfig.aiPriceTuneLookbackCycles)
+    val consumptions = LinkSource.loadLinkConsumptionsByAirline(airline.id, lookback)
+    if (consumptions.isEmpty) return 0
+
+    val lowLF = SoloConfig.aiPriceTuneLowLoadFactor
+    val highLF = SoloConfig.aiPriceTuneHighLoadFactor
+    val midLF = (lowLF + highLF) / 2
+
+    // Average load factor per link over the window; only links that are out of the comfort band
+    // and whose price would actually move are candidates.
+    val candidates = consumptions.filter(_.link.getTotalCapacity > 0).groupBy(_.link.id).flatMap { case (linkId, entries) =>
+      val avgLF = entries.map(_.link.getLoadFactor).sum / entries.size
+      val factor = priceNudgeFactor(avgLF, lowLF, highLF, SoloConfig.aiPriceTuneStep)
+      if (factor == 1.0) None
+      else entries.maxBy(_.cycle).link match {
+        case link : Link =>
+          val std = standardPrice(link.from, link.to, link.distance)
+          val newPrice = nudgedPrice(link.price, std, factor, SoloConfig.aiPriceTuneFloorRatio, SoloConfig.aiPriceTuneCeilRatio)
+          if (newPrice == link.price) None else Some((linkId, link, avgLF, newPrice))
+        case _ => None
+      }
+    }.toList
+
+    // Touch only the few most out-of-equilibrium links per cycle.
+    val chosen = candidates.sortBy(c => -Math.abs(c._3 - midLF)).take(Math.max(0, SoloConfig.aiPriceTuneMaxLinksPerAirline))
+    chosen.foreach { case (linkId, link, avgLF, newPrice) =>
+      LinkSource.updateLinkPrice(linkId, newPrice)
+      println(f"[ai-pricetune] ${airline.name} ${link.from.iata}-${link.to.iata} LF=$avgLF%.2f econ ${link.price.economyVal}->${newPrice.economyVal}")
+    }
+    chosen.size
+  }
+
+  private def standardPrice(from : Airport, to : Airport, distance : Int) : LinkClassValues = {
+    val category = Computation.getFlightCategory(from, to)
+    LinkClassValues(
+      Pricing.computeStandardPrice(distance, category, ECONOMY, PassengerType.TRAVELER, from.baseIncome),
+      Pricing.computeStandardPrice(distance, category, BUSINESS, PassengerType.BUSINESS, from.baseIncome),
+      Pricing.computeStandardPrice(distance, category, FIRST, PassengerType.BUSINESS, from.baseIncome))
+  }
+}

--- a/airline-data/src/main/scala/com/patson/ComputerAirlineSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/ComputerAirlineSimulation.scala
@@ -16,8 +16,9 @@ import com.patson.model.NonPlayerAirline
   */
 object ComputerAirlineSimulation {
   def simulate(cycle : Int) : Unit = {
-    // Drops (aiEnabled) and growth (aiGrowthEnabled) are independent; run if either is on.
-    if (!SoloConfig.aiEnabled && !SoloConfig.aiGrowthEnabled) return
+    // Drops (aiEnabled), growth (aiGrowthEnabled) and price tuning (aiPriceTuneEnabled) are
+    // independent; run if any is on.
+    if (!SoloConfig.aiEnabled && !SoloConfig.aiGrowthEnabled && !SoloConfig.aiPriceTuneEnabled) return
 
     try {
       val npcAirlines = AirlineSource.loadAirlinesByCriteria(List(("airline_type", NonPlayerAirline.id)))
@@ -64,7 +65,14 @@ object ComputerAirlineSimulation {
         totalOpens = ComputerAirlineGrowth.grow(acting, allAirports, playerIds, cycle)
       }
 
-      println(s"[ai] cycle $cycle: ${acting.size} NPC airline(s) acted, $totalDrops dropped, $totalOpens opened")
+      // Price tuning (H-2): each acting NPC nudges prices on a few existing links toward
+      // equilibrium by recent load factor. No-op unless aiPriceTuneEnabled.
+      var totalTuned = 0
+      if (SoloConfig.aiPriceTuneEnabled) {
+        totalTuned = ComputerAirlinePriceTuning.tune(acting, cycle)
+      }
+
+      println(s"[ai] cycle $cycle: ${acting.size} NPC airline(s) acted, $totalDrops dropped, $totalOpens opened, $totalTuned repriced")
     } catch {
       case e : Exception => println(s"[ai] ComputerAirlineSimulation failed (skipping): ${e.getClass.getSimpleName}: ${e.getMessage}")
     }

--- a/airline-data/src/main/scala/com/patson/data/LinkSource.scala
+++ b/airline-data/src/main/scala/com/patson/data/LinkSource.scala
@@ -516,6 +516,25 @@ object LinkSource {
     }
   }
 
+  /**
+   * Targeted price-only update: rewrites just the price columns, leaving capacity / frequency /
+   * airplane assignment / quality untouched. Safe for callers that only have a price change and
+   * not a fully-loaded link (unlike updateLink, which rewrites the airplane_model from the passed
+   * link and would clobber the assignment if it were absent). Used by the solo AI price tuning.
+   */
+  def updateLinkPrice(linkId : Int, price : LinkClassValues) : Int = {
+    Using.resource(Meta.getConnection()) { connection =>
+      Using.resource(connection.prepareStatement("UPDATE " + LINK_TABLE + " SET price_economy = ?, price_business = ?, price_first = ?, last_update = ? WHERE id = ?")) { preparedStatement =>
+        preparedStatement.setInt(1, price(ECONOMY))
+        preparedStatement.setInt(2, price(BUSINESS))
+        preparedStatement.setInt(3, price(FIRST))
+        preparedStatement.setTimestamp(4, new java.sql.Timestamp(new Date().getTime()))
+        preparedStatement.setInt(5, linkId)
+        preparedStatement.executeUpdate()
+      }
+    }
+  }
+
   def updateLinks[T <: Transport](links : List[T]) = {
     val existingLinks = loadLinksByIds(links.map(_.id)).map(link => (link.id, link)).toMap
     val changeEntries = ListBuffer[LinkChange]()

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -88,6 +88,22 @@ object SoloConfig {
   // Service quality assumed for an NPC-opened route (feeds price/cost estimation).
   val aiGrowthRawQuality : Int = intAt("solo.ai.growth.rawQuality", 40)
 
+  // Living-world AI price tuning (Phase H-2). Off by default; independent of the other ai flags.
+  // When on, each acting NPC nudges prices on a few of its existing links toward equilibrium by
+  // recent load factor: a persistently full route edges its price up (capture revenue), a
+  // persistently empty one edges down (fill seats, and undercut a competitor). Small bounded step,
+  // clamped to a band around the standard price so prices never run away — this is what makes
+  // competition feel adaptive without new-route churn. No aircraft/fleet changes here.
+  val aiPriceTuneEnabled : Boolean = boolAt("solo.ai.pricetune.enabled", false)
+  val aiPriceTuneMaxAirlinesPerCycle : Int = intAt("solo.ai.pricetune.maxAirlinesPerCycle", 3)
+  val aiPriceTuneMaxLinksPerAirline : Int = intAt("solo.ai.pricetune.maxLinksPerAirline", 5)
+  val aiPriceTuneStep : Double = doubleAt("solo.ai.pricetune.step", 0.05)
+  val aiPriceTuneHighLoadFactor : Double = doubleAt("solo.ai.pricetune.highLoadFactor", 0.85)
+  val aiPriceTuneLowLoadFactor : Double = doubleAt("solo.ai.pricetune.lowLoadFactor", 0.5)
+  val aiPriceTuneFloorRatio : Double = doubleAt("solo.ai.pricetune.floorRatio", 0.6)
+  val aiPriceTuneCeilRatio : Double = doubleAt("solo.ai.pricetune.ceilRatio", 1.5)
+  val aiPriceTuneLookbackCycles : Int = intAt("solo.ai.pricetune.lookbackCycles", 4)
+
   // World news feed (single-player): an ambient, pull-based log of notable world
   // events (NPC route changes, etc.) surfaced in a dedicated News panel, separate from
   // the personal notification bell. Off by default. Reuses the notification store under

--- a/airline-data/src/test/scala/com/patson/ComputerAirlinePriceTuningSpec.scala
+++ b/airline-data/src/test/scala/com/patson/ComputerAirlinePriceTuningSpec.scala
@@ -1,0 +1,46 @@
+package com.patson
+
+import com.patson.model.LinkClassValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+/**
+ * Phase H-2: pure decision helpers for NPC price tuning (no DB). Encodes the bounded,
+ * load-factor-driven nudge and the clamp to a band around the standard price.
+ */
+class ComputerAirlinePriceTuningSpec extends AnyWordSpecLike with Matchers {
+
+  "priceNudgeFactor".must {
+    "nudge price up when the route is persistently full".in {
+      ComputerAirlinePriceTuning.priceNudgeFactor(0.95, lowLF = 0.5, highLF = 0.85, step = 0.05) shouldBe 1.05
+    }
+    "nudge price down when the route is persistently empty".in {
+      ComputerAirlinePriceTuning.priceNudgeFactor(0.30, 0.5, 0.85, 0.05) shouldBe 0.95
+    }
+    "leave price unchanged in the comfortable middle band".in {
+      ComputerAirlinePriceTuning.priceNudgeFactor(0.70, 0.5, 0.85, 0.05) shouldBe 1.0
+    }
+    "treat the thresholds as inclusive".in {
+      ComputerAirlinePriceTuning.priceNudgeFactor(0.85, 0.5, 0.85, 0.05) shouldBe 1.05
+      ComputerAirlinePriceTuning.priceNudgeFactor(0.50, 0.5, 0.85, 0.05) shouldBe 0.95
+    }
+  }
+
+  "nudgedPrice".must {
+    val standard = LinkClassValues(200, 500, 1000)
+    "scale each class by the factor when within the band".in {
+      val current = LinkClassValues(200, 500, 1000)
+      ComputerAirlinePriceTuning.nudgedPrice(current, standard, factor = 1.05, floorRatio = 0.6, ceilRatio = 1.5) shouldBe LinkClassValues(210, 525, 1050)
+    }
+    "never exceed the ceiling band even after repeated raises".in {
+      val current = LinkClassValues(295, 740, 1480) // already near 1.5x standard
+      val out = ComputerAirlinePriceTuning.nudgedPrice(current, standard, factor = 1.05, floorRatio = 0.6, ceilRatio = 1.5)
+      out shouldBe LinkClassValues(300, 750, 1500) // clamped to 1.5x
+    }
+    "never drop below the floor band even after repeated cuts".in {
+      val current = LinkClassValues(125, 310, 620) // near 0.6x standard
+      val out = ComputerAirlinePriceTuning.nudgedPrice(current, standard, factor = 0.95, floorRatio = 0.6, ceilRatio = 1.5)
+      out shouldBe LinkClassValues(120, 300, 600) // clamped to 0.6x
+    }
+  }
+}


### PR DESCRIPTION
Phase H-2 from docs/ai-growth-plan.md — the adaptive middle between H-1 opens and drops. Each acting NPC nudges prices on a few of its existing links toward equilibrium by recent load factor (full → up to capture revenue, empty → down to fill seats / undercut a rival). One small bounded step/cycle, clamped to a band around standard price so prices never run away; capped links/airline; existing links only via a targeted price-only update (never clobbers the airplane assignment); no news spam.

Gated `solo.ai.pricetune.enabled` (default off), independent of the other ai flags; this PR also enables it. Compile-gated, 18/18 tests pass (11 H-1 + 7 H-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)