### PR TITLE
feat(data): living-world AI fleet renewal (H-3) + enable

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -41,6 +41,7 @@ jobs:
             -Dsolo.ai.enabled=true
             -Dsolo.ai.growth.enabled=true
             -Dsolo.ai.pricetune.enabled=true
+            -Dsolo.ai.fleet.enabled=true
             -Dsolo.news.enabled=true
             -Dsolo.demand.memoize=true
             -Dsolo.progression.enabled=true

--- a/airline-data/src/main/scala/com/patson/ComputerAirlineFleet.scala
+++ b/airline-data/src/main/scala/com/patson/ComputerAirlineFleet.scala
@@ -1,0 +1,37 @@
+package com.patson
+
+import com.patson.data.{AirlineSource, SoloConfig}
+import com.patson.model.Airline
+
+/**
+  * Phase H-3 of the living-world AI: keep NPC fleets from quietly decaying to nothing over long
+  * games. The sim already renews worn aircraft in place — `AirplaneSimulation.renewAirplanes` buys a
+  * replacement, sells the old frame via the ledger, resets condition, and keeps the same airplane id
+  * so link assignments are preserved — BUT only for airlines that have an "airplane renewal"
+  * threshold set. Players get one at sign-up (40); NPCs never do, so their planes decay to condition
+  * 0 and get scrapped, shrinking the network over a long game.
+  *
+  * H-3 simply seeds that threshold for NPCs, so the existing, battle-tested renewal path keeps their
+  * fleets alive. It is financially self-limiting (renewAirplanes already respects each airline's
+  * balance and minimum renewal balance, renewing lowest-condition frames first). No new
+  * purchase/ledger/assignment logic is introduced.
+  *
+  * Gated behind solo.ai.fleet.enabled (default off) — a no-op otherwise.
+  */
+object ComputerAirlineFleet {
+  /** Which NPCs still need a renewal threshold seeded, as (airlineId, threshold) pairs. Pure;
+    * unit-tested in ComputerAirlineFleetSpec. */
+  def renewalSeeds(npcIds : Seq[Int], alreadySet : Set[Int], threshold : Int) : List[(Int, Int)] =
+    npcIds.distinct.filterNot(alreadySet.contains).map(id => (id, threshold)).toList
+
+  /** Ensure every NPC has an airplane-renewal threshold so the sim renews their aging fleet.
+    * Idempotent — only seeds airlines that don't already have one. Returns the number seeded. */
+  def ensureRenewal(npcAirlines : Seq[Airline]) : Int = {
+    if (!SoloConfig.aiFleetEnabled) return 0
+    val alreadySet = AirlineSource.loadAirplaneRenewals().keySet
+    val seeds = renewalSeeds(npcAirlines.map(_.id), alreadySet, SoloConfig.aiFleetRenewalThreshold)
+    seeds.foreach { case (airlineId, threshold) => AirlineSource.saveAirplaneRenewal(airlineId, threshold) }
+    if (seeds.nonEmpty) println(s"[ai-fleet] seeded renewal threshold ${SoloConfig.aiFleetRenewalThreshold} for ${seeds.size} NPC airline(s)")
+    seeds.size
+  }
+}

--- a/airline-data/src/main/scala/com/patson/ComputerAirlineSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/ComputerAirlineSimulation.scala
@@ -16,9 +16,8 @@ import com.patson.model.NonPlayerAirline
   */
 object ComputerAirlineSimulation {
   def simulate(cycle : Int) : Unit = {
-    // Drops (aiEnabled), growth (aiGrowthEnabled) and price tuning (aiPriceTuneEnabled) are
-    // independent; run if any is on.
-    if (!SoloConfig.aiEnabled && !SoloConfig.aiGrowthEnabled && !SoloConfig.aiPriceTuneEnabled) return
+    // Drops, growth, price tuning and fleet renewal are independent flags; run if any is on.
+    if (!SoloConfig.aiEnabled && !SoloConfig.aiGrowthEnabled && !SoloConfig.aiPriceTuneEnabled && !SoloConfig.aiFleetEnabled) return
 
     try {
       val npcAirlines = AirlineSource.loadAirlinesByCriteria(List(("airline_type", NonPlayerAirline.id)))
@@ -27,6 +26,10 @@ object ComputerAirlineSimulation {
       // Resolve the player airlines once so each drop can be reported to the news feed
       // (no-op / empty unless solo.news.enabled).
       val playerIds = WorldNews.playerAirlineIds()
+
+      // Fleet renewal (H-3): seed an airplane-renewal threshold for NPCs so the sim keeps their
+      // aging fleets alive (no-op unless aiFleetEnabled). Covers all NPCs, idempotent.
+      val totalSeeded = if (SoloConfig.aiFleetEnabled) ComputerAirlineFleet.ensureRenewal(npcAirlines) else 0
 
       // Act on a rotating, bounded subset each cycle to keep the cost small.
       val perCycle = Math.max(1, SoloConfig.aiAirlinesPerCycle)
@@ -72,7 +75,7 @@ object ComputerAirlineSimulation {
         totalTuned = ComputerAirlinePriceTuning.tune(acting, cycle)
       }
 
-      println(s"[ai] cycle $cycle: ${acting.size} NPC airline(s) acted, $totalDrops dropped, $totalOpens opened, $totalTuned repriced")
+      println(s"[ai] cycle $cycle: ${acting.size} NPC airline(s) acted, $totalDrops dropped, $totalOpens opened, $totalTuned repriced, $totalSeeded renewal-seeded")
     } catch {
       case e : Exception => println(s"[ai] ComputerAirlineSimulation failed (skipping): ${e.getClass.getSimpleName}: ${e.getMessage}")
     }

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -104,6 +104,15 @@ object SoloConfig {
   val aiPriceTuneCeilRatio : Double = doubleAt("solo.ai.pricetune.ceilRatio", 1.5)
   val aiPriceTuneLookbackCycles : Int = intAt("solo.ai.pricetune.lookbackCycles", 4)
 
+  // Living-world AI fleet renewal (Phase H-3). Off by default; independent of the other ai flags.
+  // The sim already renews worn aircraft in place (buy replacement, sell old via ledger, reset
+  // condition, keep airplane id so link assignments survive) but only for airlines with an
+  // "airplane renewal" threshold; players get one at sign-up, NPCs never do, so NPC fleets decay to
+  // scrap and networks shrink. When on, seed that threshold for NPCs so the existing (financially
+  // self-limiting) renewal path keeps their fleets alive. Renew when condition < renewalThreshold.
+  val aiFleetEnabled : Boolean = boolAt("solo.ai.fleet.enabled", false)
+  val aiFleetRenewalThreshold : Int = intAt("solo.ai.fleet.renewalThreshold", 40)
+
   // World news feed (single-player): an ambient, pull-based log of notable world
   // events (NPC route changes, etc.) surfaced in a dedicated News panel, separate from
   // the personal notification bell. Off by default. Reuses the notification store under

--- a/airline-data/src/test/scala/com/patson/ComputerAirlineFleetSpec.scala
+++ b/airline-data/src/test/scala/com/patson/ComputerAirlineFleetSpec.scala
@@ -1,0 +1,29 @@
+package com.patson
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+/**
+ * Phase H-3: the pure helper deciding which NPCs still need an airplane-renewal threshold seeded
+ * (so the existing AirplaneSimulation.renewAirplanes path keeps their fleets alive). The renewal
+ * economics themselves are the engine's existing, tested logic.
+ */
+class ComputerAirlineFleetSpec extends AnyWordSpecLike with Matchers {
+
+  "renewalSeeds".must {
+    "seed only NPCs that don't already have a threshold".in {
+      ComputerAirlineFleet.renewalSeeds(Seq(1, 2, 3), alreadySet = Set(2), threshold = 40) should
+        contain theSameElementsAs List((1, 40), (3, 40))
+    }
+    "seed nothing when every NPC already has one".in {
+      ComputerAirlineFleet.renewalSeeds(Seq(1, 2), alreadySet = Set(1, 2, 99), threshold = 40) shouldBe empty
+    }
+    "dedupe repeated ids".in {
+      ComputerAirlineFleet.renewalSeeds(Seq(5, 5, 6), alreadySet = Set.empty, threshold = 30) should
+        contain theSameElementsAs List((5, 30), (6, 30))
+    }
+    "carry the configured threshold".in {
+      ComputerAirlineFleet.renewalSeeds(Seq(9), alreadySet = Set.empty, threshold = 25) shouldBe List((9, 25))
+    }
+  }
+}


### PR DESCRIPTION
Phase H-3 from docs/ai-growth-plan.md — stop NPC fleets from quietly decaying to scrap over long games. The sim already renews worn aircraft in place (`AirplaneSimulation.renewAirplanes`: buys a replacement, sells the old via the ledger, resets condition, keeps the airplane id so link assignments survive), gated on an 'airplane renewal' threshold that players get at sign-up (40) but NPCs never do. H-3 seeds that threshold for NPCs so the existing, financially self-limiting renewal path keeps their fleets alive — no new purchase/ledger/assignment code.

Gated `solo.ai.fleet.enabled` (default off), independent of the other ai flags; this PR also enables it. Compile-gated, 22/22 tests pass (11 H-1 + 7 H-2 + 4 H-3). Buy-to-grow for H-1 deferred (would change the growth cadence under evaluation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)