### PR TITLE
feat(web): add 'Modified' column to the Flights table

### DIFF
--- a/airline-web/app/views/fragments/links_canvas.scala.html
+++ b/airline-web/app/views/fragments/links_canvas.scala.html
@@ -58,6 +58,9 @@
 							<div class="cell clickable" style="width: 8%" align="right"
 								data-sort-property="profitPerStaff" data-sort-order="ascending"
 								onclick="toggleLinksTableSortOrder($(this))">Profit per staff</div>
+							<div class="cell clickable" style="width: 7%" align="right"
+								data-sort-property="lastUpdate" data-sort-order="descending"
+								onclick="toggleLinksTableSortOrder($(this))" title="When you last edited this route (real time)">Modified</div>
 						</div>
 						<div class="table-header" id="linksTableFilterHeader" style="display: none;">
 							<div class="cell" style="width: 3%">&nbsp;</div>
@@ -76,6 +79,7 @@
 							<div class="cell" style="width: 7%">&nbsp;</div>
 							<div class="cell" style="width: 6%">&nbsp;</div>
 							<div class="cell" style="width: 8%">&nbsp;</div>
+							<div class="cell" style="width: 7%">&nbsp;</div>
 						</div>
 					</div>
 					<div class="table-container-y" style="min-width: 980px;">

--- a/airline-web/public/javascripts/airline.js
+++ b/airline-web/public/javascripts/airline.js
@@ -2028,6 +2028,21 @@ document.addEventListener('distanceUnitChanged', function() {
     }
 });
 
+// Compact "time ago" for the Flights table Modified column. lastUpdate is real-world epoch ms.
+function formatLastModified(epochMs) {
+    if (!epochMs) return '-'
+    var diff = Date.now() - Number(epochMs)
+    if (diff < 0) diff = 0
+    var mins = Math.floor(diff / 60000)
+    if (mins < 1) return 'just now'
+    if (mins < 60) return mins + 'm ago'
+    var hrs = Math.floor(mins / 60)
+    if (hrs < 24) return hrs + 'h ago'
+    var days = Math.floor(hrs / 24)
+    if (days < 30) return days + 'd ago'
+    return new Date(Number(epochMs)).toLocaleDateString()
+}
+
 function loadLinksTable(onComplete, forceRefresh) {
     const linksTable = $('#linksCanvas #linksTable');
     if (!linksTable.data('delegation-set')) {
@@ -2113,7 +2128,8 @@ function addSummaryRow(links) {
         { getValue: (link) => link.displayProfit, format: (val) => '$' + commaSeparateNumber(val.toFixed(0)) },
         { getValue: (link) => link.displayProfitMargin, format: (val) => (val * 100).toFixed(2) + "%" },
         { getValue: (link) => link.currentStaffRequired, format: (val) => val },
-        { getValue: (link) => link.profitPerStaff, format: (val) => '$' + commaSeparateNumber(val.toFixed(0)) }
+        { getValue: (link) => link.profitPerStaff, format: (val) => '$' + commaSeparateNumber(val.toFixed(0)) },
+        {} // Modified (non-numeric; keeps the summary row column-aligned)
     ];
     addTableSummaryRow("#linksCanvas #linksTable", data, linkColumnConfigs, linksTableSummaryState);
 }
@@ -2169,6 +2185,7 @@ function updateLinksTable(sortProperty, sortOrder) {
             `<div class='cell${avgClass}' align='right' data-label='Margin'>${(link.displayProfitMargin * 100).toFixed(2)}%</div>` +
             `<div class='cell' align='right' data-label='Staff'>${link.currentStaffRequired}</div>` +
             `<div class='cell' align='right' data-label='Profit / Staff'>$${commaSeparateNumber(link.profitPerStaff)}</div>` +
+            `<div class='cell' align='right' data-label='Modified'>${formatLastModified(link.lastUpdate)}</div>` +
             `</div>`
         );
     });


### PR DESCRIPTION
Adds a visible, sortable **Modified** column to the Flights table showing when each route was last edited (compact time-ago, e.g. '3d ago'). The data was already sent to the client (lastUpdate epoch ms from /links-details) and a hidden last-updated sort already existed (the clock-icon quick-sort) — this just makes the value visible. Appended to header, rows, summary row, and filter row to keep column alignment intact. Web-only (HTML + JS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)