### PR TITLE
feat(data): route/fleet consultant engine + manager task (backend, gated)

### DIFF
--- a/airline-data/src/main/scala/com/patson/ConsultantAdvisor.scala
+++ b/airline-data/src/main/scala/com/patson/ConsultantAdvisor.scala
@@ -1,0 +1,148 @@
+package com.patson
+
+import com.patson.data.{AirlineSource, LinkSource, SoloConfig}
+import com.patson.model._
+import com.patson.model.airplane.{Airplane, AirplaneConfiguration, LinkAssignment, Model}
+
+/**
+  * Route/fleet consultant engine (single-player QOL, Phase "Advisor"). Studies a player airline's
+  * network and surfaces the most profitable route opportunities it isn't already serving — ranked by
+  * a real-cost-model profit estimate — plus a suggested aircraft + cabin config. Advice-only: it
+  * never opens or changes anything.
+  *
+  * Shares the same underlying primitives as the NPC growth path (DemandGenerator base demand,
+  * Pricing, LinkSimulation cost model) but is independent of it, so the live NPC code is untouched.
+  * How much advice is produced scales with the assigned consultant(s)' level (the leveling-manager
+  * proficiency) and how many are assigned, capped for balance.
+  */
+object ConsultantAdvisor {
+  private val SEAT_TARGET_MULTIPLIER = 1.5
+
+  case class Recommendation(from : Airport, to : Airport, distance : Int, estWeeklyProfit : Long, model : Model, config : AirplaneConfiguration)
+
+  /** How many recommendations to surface, from the assigned consultants' levels (pure; tested).
+    * Empty → 0 (no consultant). Best level drives depth; extra consultants add a little; capped. */
+  def adviceDepth(levels : Seq[Int]) : Int = {
+    if (levels.isEmpty) 0
+    else {
+      val best = levels.max
+      val extra = levels.size - 1
+      Math.min(SoloConfig.consultantMaxRecs,
+        SoloConfig.consultantBaseRecs + best * SoloConfig.consultantRecsPerLevel + extra * SoloConfig.consultantRecsPerExtraConsultant)
+    }
+  }
+
+  /** Top route recommendations for the airline, using models it already owns. allAirports and
+    * countryRelationships are loaded once by the caller. */
+  def recommendations(airline : Airline,
+                      levels : Seq[Int],
+                      allAirports : List[Airport],
+                      countryRelationships : Map[(String, String), Int],
+                      ownedModels : List[Model],
+                      currentCycle : Int) : List[Recommendation] = {
+    val depth = adviceDepth(levels)
+    if (depth <= 0 || ownedModels.isEmpty) return Nil
+
+    val airportById = allAirports.map(a => (a.id, a)).toMap
+    val baseAirports = AirlineSource.loadAirlineBasesByAirline(airline.id).flatMap(b => airportById.get(b.airport.id))
+    if (baseAirports.isEmpty) return Nil
+
+    val served : Set[(Int, Int)] = LinkSource.loadFlightLinksByAirlineId(airline.id)
+      .flatMap(l => List((l.from.id, l.to.id), (l.to.id, l.from.id))).toSet
+
+    val maxRange = ownedModels.map(_.range).max
+    val minRunway = ownedModels.map(_.runwayRequirement).min
+
+    val candidates = baseAirports.flatMap { home =>
+      rankedDestinations(home, maxRange, minRunway, allAirports, served, countryRelationships, SoloConfig.consultantCandidateLimit)
+        .map { case (to, demand) => (home, to, demand) }
+    }
+
+    val scored = candidates.flatMap { case (home, to, demand) =>
+      bestForRoute(airline, home, to, demand, ownedModels, countryRelationships, currentCycle)
+    }
+    scored.filter(_.estWeeklyProfit > 0).sortBy(-_.estWeeklyProfit).take(depth)
+  }
+
+  private def rankedDestinations(home : Airport, maxRange : Int, minRunway : Int, allAirports : List[Airport],
+                                 served : Set[(Int, Int)], countryRelationships : Map[(String, String), Int], limit : Int) : List[(Airport, DemandGenerator.Demand)] = {
+    allAirports.iterator.filter { to =>
+      to.id != home.id && to.runwayLength >= minRunway && !served.contains((home.id, to.id))
+    }.flatMap { to =>
+      val distance = Computation.calculateDistance(home, to)
+      if (distance <= 0 || distance > maxRange || !DemandGenerator.canHaveDemand(home, to, distance)) None
+      else {
+        val rel = countryRelationships.getOrElse((home.countryCode, to.countryCode), 0)
+        if (rel < 0) None
+        else {
+          val affinity = Computation.calculateAffinityValue(home.zone, to.zone, rel)
+          val demand = DemandGenerator.computeBaseDemandBetweenAirports(home, to, affinity, distance)
+          val total = demand.travelerDemand.total + demand.businessDemand.total + demand.touristDemand.total
+          if (total <= 0) None else Some((to, demand, total))
+        }
+      }
+    }.toList.sortBy(-_._3).take(Math.max(1, limit)).map { case (a, d, _) => (a, d) }
+  }
+
+  /** Best owned model for this route, with its profit estimate. */
+  private def bestForRoute(airline : Airline, from : Airport, to : Airport, demand : DemandGenerator.Demand,
+                           models : List[Model], countryRelationships : Map[(String, String), Int], currentCycle : Int) : Option[Recommendation] = {
+    val distance = Computation.calculateDistance(from, to)
+    val fitting = models.filter(m => m.range >= distance && to.runwayLength >= m.runwayRequirement && from.runwayLength >= m.runwayRequirement)
+    if (fitting.isEmpty) return None
+    val bothWays = demandByClass(from, to, countryRelationships) + demandByClass(to, from, countryRelationships)
+    fitting.flatMap { model =>
+      buildLink(airline, from, to, model, demand, distance, currentCycle).map { case (link, config) =>
+        Recommendation(from, to, distance, estimateWeeklyProfit(link, bothWays, currentCycle), model, config)
+      }
+    }.sortBy(-_.estWeeklyProfit).headOption
+  }
+
+  private def buildLink(airline : Airline, from : Airport, to : Airport, model : Model, demand : DemandGenerator.Demand, distance : Int, currentCycle : Int) : Option[(Link, AirplaneConfiguration)] = {
+    val flightMinutesPerFreq = Computation.calculateFlightMinutesRequired(model, distance)
+    if (flightMinutesPerFreq <= 0) return None
+    val config = AirplaneConfiguration.default(airline, model)
+    val seatsPerFlight = config.economyVal + config.businessVal + config.firstVal
+    if (seatsPerFlight <= 0) return None
+    val demandTotal = demand.travelerDemand.total + demand.businessDemand.total + demand.touristDemand.total
+    val targetSeats = (demandTotal * SEAT_TARGET_MULTIPLIER).toInt
+    val freqForDemand = Math.max(1, Math.ceil(targetSeats.toDouble / seatsPerFlight).toInt)
+    val freqByMinutes = Airplane.MAX_FLIGHT_MINUTES / flightMinutesPerFreq
+    val frequency = Math.min(Math.min(freqForDemand, freqByMinutes), Computation.calculateMaxFrequency(model, distance))
+    if (frequency <= 0) return None
+
+    val priceMod = if (from.popMiddleIncome < 100_000 || to.popMiddleIncome < 100_000) 1.2 else 1.0
+    val cat = Computation.getFlightCategory(from, to)
+    val econ = (priceMod * Pricing.computeStandardPrice(distance, cat, ECONOMY, PassengerType.TRAVELER, from.baseIncome)).toInt
+    val biz = (priceMod * Pricing.computeStandardPrice(distance, cat, BUSINESS, PassengerType.BUSINESS, from.baseIncome)).toInt
+    val first = (priceMod * Pricing.computeStandardPrice(distance, cat, FIRST, PassengerType.BUSINESS, from.baseIncome)).toInt
+    val duration = Computation.calculateDuration(model, distance)
+    val airplane = Airplane(model, airline, currentCycle, currentCycle, Airplane.MAX_CONDITION, model.price, isSold = false, configuration = config, home = from, isReady = true)
+    val assignment = LinkAssignment(frequency, frequency * flightMinutesPerFreq)
+    val capacity = LinkClassValues(config.economyVal, config.businessVal, config.firstVal) * frequency
+    val link = Link(from, to, airline, LinkClassValues(econ, biz, first), distance, capacity, 40, duration = duration, frequency = frequency)
+    link.setAssignedAirplanes(Map(airplane -> assignment))
+    Some((link, config))
+  }
+
+  private def estimateWeeklyProfit(link : Link, demandByClass : LinkClassValues, currentCycle : Int) : Long = {
+    val capture = SoloConfig.consultantCaptureRatio
+    val cap = link.capacity
+    val est = LinkClassValues(
+      Math.min(cap.economyVal, (demandByClass.economyVal * capture).toInt),
+      Math.min(cap.businessVal, (demandByClass.businessVal * capture).toInt),
+      Math.min(cap.firstVal, (demandByClass.firstVal * capture).toInt))
+    link.addSoldSeats(est)
+    val profit = LinkSimulation.computeFlightLinkConsumptionDetail(link, currentCycle).profit
+    link.soldSeats = LinkClassValues.getInstance()
+    profit.toLong
+  }
+
+  private def demandByClass(from : Airport, to : Airport, countryRelationships : Map[(String, String), Int]) : LinkClassValues = {
+    val distance = Computation.calculateDistance(from, to)
+    val rel = countryRelationships.getOrElse((from.countryCode, to.countryCode), 0)
+    val affinity = Computation.calculateAffinityValue(from.zone, to.zone, rel)
+    val d = DemandGenerator.computeBaseDemandBetweenAirports(from, to, affinity, distance)
+    d.travelerDemand + d.businessDemand + d.touristDemand
+  }
+}

--- a/airline-data/src/main/scala/com/patson/data/Constants.scala
+++ b/airline-data/src/main/scala/com/patson/data/Constants.scala
@@ -137,6 +137,7 @@ object Constants {
   val CAMPAIGN_AREA_TABLE = "campaign_area"
   val CAMPAIGN_DELEGATE_TASK_TABLE = "campaign_delegate_task"
   val AIRCRAFT_MODEL_DELEGATE_TASK_TABLE = "airplane_model_delegate_task"
+  val CONSULTANT_DELEGATE_TASK_TABLE = "consultant_delegate_task"
 
   val ALLIANCE_MISSION_TABLE = "alliance_mission"
   val ALLIANCE_MISSION_PROPERTY_TABLE = "alliance_mission_property"

--- a/airline-data/src/main/scala/com/patson/data/ManagerSource.scala
+++ b/airline-data/src/main/scala/com/patson/data/ManagerSource.scala
@@ -123,6 +123,8 @@ object ManagerSource {
             managerIdsOfThisTaskType.foreach(id => result.put(id, ManagerBaseTask()))
           case ManagerTaskType.MANAGER_AIRCRAFT_MODEL =>
             result.addAll(loadAircraftModelTasks(managerIdsOfThisTaskType))
+          case ManagerTaskType.CONSULTANT =>
+            result.addAll(loadConsultantTasks(managerIdsOfThisTaskType))
         }
       }
     }
@@ -160,6 +162,40 @@ object ManagerSource {
       connection.close()
     }
 
+  }
+
+  def loadConsultantTasks(managerIds : List[Int]) : Map[Int, ManagerTask] = {
+    if (managerIds.isEmpty) return Map.empty
+    val connection = Meta.getConnection()
+    try {
+      val managerIdPhrase = managerIds.mkString(",")
+      val preparedStatement = connection.prepareStatement(s"SELECT * FROM $CONSULTANT_DELEGATE_TASK_TABLE WHERE delegate IN ($managerIdPhrase)")
+      val resultSet = preparedStatement.executeQuery()
+      val result = mutable.Map[Int, ManagerTask]()
+      while (resultSet.next()) {
+        result.put(resultSet.getInt("delegate"), ConsultantManagerTask(resultSet.getInt("start_cycle")))
+      }
+      resultSet.close()
+      preparedStatement.close()
+      result.toMap
+    } finally {
+      connection.close()
+    }
+  }
+
+  private[this] def saveConsultantTasks(managers: List[Manager]) = {
+    val connection = Meta.getConnection()
+    val preparedStatement = connection.prepareStatement("INSERT INTO " + CONSULTANT_DELEGATE_TASK_TABLE + "(delegate, start_cycle) VALUES(?,?)")
+    try {
+      managers.foreach { manager =>
+        preparedStatement.setInt(1, manager.id)
+        preparedStatement.setInt(2, manager.assignedTask.getStartCycle)
+        preparedStatement.executeUpdate()
+      }
+    } finally {
+      preparedStatement.close()
+      connection.close()
+    }
   }
 
   def loadCampaignCostsByAirlineId() : Map[Int, Int] = {
@@ -417,6 +453,8 @@ object ManagerSource {
             // no per-task table; task_type in busy_delegate is sufficient
           case ManagerTaskType.MANAGER_AIRCRAFT_MODEL =>
             saveAircraftModelTasks(delegatesOfThisTaskType)
+          case ManagerTaskType.CONSULTANT =>
+            saveConsultantTasks(delegatesOfThisTaskType)
         }
       }
     }

--- a/airline-data/src/main/scala/com/patson/data/Meta.scala
+++ b/airline-data/src/main/scala/com/patson/data/Meta.scala
@@ -1279,6 +1279,9 @@ object Meta {
     statement = connection.prepareStatement("DROP TABLE IF EXISTS " + COUNTRY_DELEGATE_TASK_TABLE)
     statement.execute()
     statement.close()
+    statement = connection.prepareStatement("DROP TABLE IF EXISTS " + CONSULTANT_DELEGATE_TASK_TABLE)
+    statement.execute()
+    statement.close()
     statement = connection.prepareStatement("DROP TABLE IF EXISTS " + LINK_NEGOTIATION_TASK_TABLE)
     statement.execute()
     statement.close()
@@ -1303,6 +1306,14 @@ object Meta {
     statement = connection.prepareStatement("CREATE TABLE " + COUNTRY_DELEGATE_TASK_TABLE + "(" +
       "delegate INTEGER PRIMARY KEY, " +
       "country_code CHAR(2), " +
+      "start_cycle INTEGER, " +
+      "FOREIGN KEY(delegate) REFERENCES " + BUSY_DELEGATE_TABLE + "(id) ON DELETE CASCADE ON UPDATE CASCADE" +
+      ")")
+    statement.execute()
+    statement.close()
+
+    statement = connection.prepareStatement("CREATE TABLE " + CONSULTANT_DELEGATE_TASK_TABLE + "(" +
+      "delegate INTEGER PRIMARY KEY, " +
       "start_cycle INTEGER, " +
       "FOREIGN KEY(delegate) REFERENCES " + BUSY_DELEGATE_TABLE + "(id) ON DELETE CASCADE ON UPDATE CASCADE" +
       ")")

--- a/airline-data/src/main/scala/com/patson/data/NotificationSource.scala
+++ b/airline-data/src/main/scala/com/patson/data/NotificationSource.scala
@@ -203,10 +203,10 @@ object NotificationSource {
   def countUnreadByAirline(airlineId: Int): Int = {
     val connection = Meta.getConnection()
     try {
-      // WORLD_NEWS lives in its own pull-based News panel, so it must not drive the
-      // personal notification bell badge (otherwise the feed would constantly nag).
+      // WORLD_NEWS and CONSULTANT_ADVICE live in their own pull-based panels (News / Advisor),
+      // so they must not drive the personal notification bell badge (otherwise they would nag).
       val statement = connection.prepareStatement(
-        s"SELECT COUNT(*) FROM $NOTIFICATION_TABLE WHERE airline = ? AND is_read = 0 AND category != '${NotificationCategory.WORLD_NEWS}'"
+        s"SELECT COUNT(*) FROM $NOTIFICATION_TABLE WHERE airline = ? AND is_read = 0 AND category != '${NotificationCategory.WORLD_NEWS}' AND category != '${NotificationCategory.CONSULTANT_ADVICE}'"
       )
       try {
         statement.setInt(1, airlineId)

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -113,6 +113,18 @@ object SoloConfig {
   val aiFleetEnabled : Boolean = boolAt("solo.ai.fleet.enabled", false)
   val aiFleetRenewalThreshold : Int = intAt("solo.ai.fleet.renewalThreshold", 40)
 
+  // Route/fleet consultant (single-player QOL). A manager assigned to the CONSULTANT task studies
+  // the player's network and surfaces profitable route opportunities (+ a suggested aircraft) that
+  // would otherwise require clicking every airport. Advice-only. Depth scales with the consultant's
+  // level and how many are assigned (capped). Off by default.
+  val consultantEnabled : Boolean = boolAt("solo.consultant.enabled", false)
+  val consultantBaseRecs : Int = intAt("solo.consultant.baseRecommendations", 3)
+  val consultantRecsPerLevel : Int = intAt("solo.consultant.recsPerLevel", 2)
+  val consultantRecsPerExtraConsultant : Int = intAt("solo.consultant.recsPerExtraConsultant", 2)
+  val consultantMaxRecs : Int = intAt("solo.consultant.maxRecommendations", 15)
+  val consultantCandidateLimit : Int = intAt("solo.consultant.candidateLimit", 40)
+  val consultantCaptureRatio : Double = doubleAt("solo.consultant.captureRatio", 0.7)
+
   // World news feed (single-player): an ambient, pull-based log of notable world
   // events (NPC route changes, etc.) surfaced in a dedicated News panel, separate from
   // the personal notification bell. Off by default. Reuses the notification store under

--- a/airline-data/src/main/scala/com/patson/model/Manager.scala
+++ b/airline-data/src/main/scala/com/patson/model/Manager.scala
@@ -97,7 +97,21 @@ object AircraftModelManagerTask {
   val MAX_MANAGERS_PER_MODEL = 2
 }
 
+/**
+ * Consultant / route advisor (single-player QOL). A manager assigned here studies the network and
+ * surfaces profitable route opportunities (and a suggested aircraft) the player would otherwise have
+ * to find by clicking every airport. Advice-only — never acts. Like other leveling tasks it gets more
+ * proficient the longer it is in the role (deeper/more recommendations); capped for balance.
+ */
+case class ConsultantManagerTask(startCycle : Int) extends LevelingManagerTask(startCycle, ManagerTaskType.CONSULTANT) {
+  override val description: String = "Advising on route & fleet opportunities"
+}
+
+object ConsultantManagerTask {
+  val MAX_CONSULTANT_MANAGERS = 3
+}
+
 object ManagerTaskType extends Enumeration {
   type ManagerTaskType = Value
-  val COUNTRY, CAMPAIGN, MANAGER_BASE, MANAGER_AIRCRAFT_MODEL = Value
+  val COUNTRY, CAMPAIGN, MANAGER_BASE, MANAGER_AIRCRAFT_MODEL, CONSULTANT = Value
 }

--- a/airline-data/src/main/scala/com/patson/model/Notification.scala
+++ b/airline-data/src/main/scala/com/patson/model/Notification.scala
@@ -63,5 +63,5 @@ object NotificationCategory extends Enumeration {
    *   bell — excluded from the bell unread count so it never nags. targetId optional, e.g.
    *   "rival_{airlineId}" for navigation. Subject to the normal retention purge.
    */
-  val NEGOTIATION_LOSS, LEVEL_UP, LOYALIST, GAME_OVER, OLYMPICS_PRIZE, TUTORIAL, LINK_CANCELLATION, CASH_FLOW_WARNING, PROFIT_MILESTONE, MILESTONE_ACHIEVED, WORLD_NEWS = Value
+  val NEGOTIATION_LOSS, LEVEL_UP, LOYALIST, GAME_OVER, OLYMPICS_PRIZE, TUTORIAL, LINK_CANCELLATION, CASH_FLOW_WARNING, PROFIT_MILESTONE, MILESTONE_ACHIEVED, WORLD_NEWS, CONSULTANT_ADVICE = Value
 }

--- a/airline-data/src/test/scala/com/patson/ConsultantAdvisorSpec.scala
+++ b/airline-data/src/test/scala/com/patson/ConsultantAdvisorSpec.scala
@@ -1,0 +1,32 @@
+package com.patson
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+/**
+ * Advisor: the pure depth helper that turns assigned consultants' levels into how many
+ * recommendations to surface (defaults: base 3, +2/level of the best, +2 per extra consultant,
+ * capped at 15).
+ */
+class ConsultantAdvisorSpec extends AnyWordSpecLike with Matchers {
+
+  "adviceDepth".must {
+    "be 0 with no consultant assigned".in {
+      ConsultantAdvisor.adviceDepth(Nil) shouldBe 0
+    }
+    "give the base count for a single trainee (level 0)".in {
+      ConsultantAdvisor.adviceDepth(Seq(0)) shouldBe 3
+    }
+    "scale with the best consultant's level".in {
+      ConsultantAdvisor.adviceDepth(Seq(2)) shouldBe 7   // 3 + 2*2
+      ConsultantAdvisor.adviceDepth(Seq(4)) shouldBe 11  // 3 + 4*2
+    }
+    "add a bonus per extra consultant, driven by the best level".in {
+      ConsultantAdvisor.adviceDepth(Seq(1, 3)) shouldBe 11 // best 3 -> 3+6, +1 extra*2
+    }
+    "cap the total".in {
+      ConsultantAdvisor.adviceDepth(Seq(4, 4, 4)) shouldBe 15 // 3 + 8 + 2*2 = 15
+      ConsultantAdvisor.adviceDepth(Seq(4, 4, 4, 4)) shouldBe 15 // would be 17, capped
+    }
+  }
+}


### PR DESCRIPTION
Backend for the single-player route/fleet **consultant** (advice-only QOL — surfaces profitable routes you'd otherwise find by clicking every airport).

- **CONSULTANT manager task** (`ConsultantManagerTask extends LevelingManagerTask`, levels up over weeks like other managers; `MAX_CONSULTANT_MANAGERS` cap for balance) + its `consultant_delegate_task` table + ManagerSource load/save wiring.
- **CONSULTANT_ADVICE notification category** (excluded from the bell, like WORLD_NEWS) — advice will be stored/displayed as a timestamped running list via the notification store (no extra report table).
- **ConsultantAdvisor engine**: ranks profitable unserved routes from the player's bases with a suggested owned model + cabin config, reusing the same demand/Pricing/cost-model primitives as NPC growth (the live NPC code is untouched). Depth scales with consultant level/count — pure `adviceDepth` helper, unit-tested.

Gated `solo.consultant.enabled` (default off) → byte-identical default deploy. Compile-gated, 27/27 tests. Web panel + assignment endpoint + refresh trigger + enable land in follow-up PRs (and a one-off DDL to create the table on the live DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)