### PR TITLE
feat(web): route consultant UI + advice endpoints (Office page)

### DIFF
--- a/airline-data/src/main/scala/com/patson/data/NotificationSource.scala
+++ b/airline-data/src/main/scala/com/patson/data/NotificationSource.scala
@@ -273,6 +273,24 @@ object NotificationSource {
     }
   }
 
+  def deleteByCategory(airlineId: Int, category: NotificationCategory.Value): Unit = {
+    val connection = Meta.getConnection()
+    try {
+      val statement = connection.prepareStatement(
+        s"DELETE FROM $NOTIFICATION_TABLE WHERE airline = ? AND category = ?"
+      )
+      try {
+        statement.setInt(1, airlineId)
+        statement.setString(2, category.toString)
+        statement.executeUpdate()
+      } finally {
+        statement.close()
+      }
+    } finally {
+      connection.close()
+    }
+  }
+
   def deleteAllRead(airlineId: Int): Unit = {
     val connection = Meta.getConnection()
     try {

--- a/airline-web/app/controllers/ManagerApplication.scala
+++ b/airline-web/app/controllers/ManagerApplication.scala
@@ -1,7 +1,8 @@
 package controllers
 
-import com.patson.data.{CampaignSource, CycleSource, ManagerSource}
+import com.patson.data.{CampaignSource, CycleSource, ManagerSource, SoloConfig}
 import com.patson.data.airplane.ModelSource
+import com.patson.ConsultantAdvisor
 import com.patson.model._
 import com.patson.model.campaign.Campaign
 import com.patson.model.airplane.{DiscountReason, DiscountType, ModelDiscount}
@@ -89,6 +90,46 @@ class ManagerApplication @Inject()(cc: ControllerComponents) extends AbstractCon
       }
     } else {
       Ok(Json.obj()) // delta == 0
+    }
+  }
+
+  def getConsultants(airlineId : Int) = AuthenticatedAirline(airlineId) { request =>
+    val currentCycle = CycleSource.loadCycle()
+    val managerInfo = request.user.getManagerInfo()
+    val leveling = managerInfo.busyManagers.filter(_.assignedTask.getTaskType == ManagerTaskType.CONSULTANT).map(_.assignedTask.asInstanceOf[LevelingManagerTask])
+    val levels = leveling.map(_.level(currentCycle))
+    val best = leveling.sortBy(t => -t.level(currentCycle)).headOption
+    Ok(Json.obj(
+      "count" -> leveling.size,
+      "maxManagers" -> ConsultantManagerTask.MAX_CONSULTANT_MANAGERS,
+      "availableCount" -> managerInfo.availableCount,
+      "bestLevel" -> (if (levels.isEmpty) 0 else levels.max),
+      "levelDescription" -> best.map(_.levelDescription(currentCycle)).getOrElse("—"),
+      "adviceDepth" -> ConsultantAdvisor.adviceDepth(levels),
+      "enabled" -> SoloConfig.consultantEnabled
+    ))
+  }
+
+  def updateConsultants(airlineId : Int) = AuthenticatedAirline(airlineId) { request =>
+    val airline = request.user
+    val managerCount = request.body.asInstanceOf[AnyContentAsJson].json.\("managerCount").as[Int]
+    val existing = ManagerSource.loadBusyManagersByAirline(airlineId).filter(_.assignedTask.getTaskType == ManagerTaskType.CONSULTANT).sortBy(_.assignedTask.getStartCycle)
+    val delta = managerCount - existing.length
+    if (managerCount < 0) {
+      BadRequest(s"Invalid manager count $managerCount")
+    } else if (managerCount > ConsultantManagerTask.MAX_CONSULTANT_MANAGERS) {
+      BadRequest(s"Invalid manager count $managerCount (max ${ConsultantManagerTask.MAX_CONSULTANT_MANAGERS})")
+    } else if (delta > airline.getManagerInfo().availableCount) {
+      BadRequest("Not enough available managers")
+    } else if (delta < 0) {
+      existing.takeRight(-delta).foreach(m => ManagerSource.deleteBusyDelegateByCriteria(List(("id", "=", m.id))))
+      Ok(Json.obj())
+    } else if (delta > 0) {
+      val task = ConsultantManagerTask(CycleSource.loadCycle())
+      ManagerSource.saveBusyManagers((0 until delta).map(_ => Manager(airline, task, None)).toList)
+      Ok(Json.obj())
+    } else {
+      Ok(Json.obj())
     }
   }
 

--- a/airline-web/app/controllers/ManagerApplication.scala
+++ b/airline-web/app/controllers/ManagerApplication.scala
@@ -97,14 +97,15 @@ class ManagerApplication @Inject()(cc: ControllerComponents) extends AbstractCon
     val currentCycle = CycleSource.loadCycle()
     val managerInfo = request.user.getManagerInfo()
     val leveling = managerInfo.busyManagers.filter(_.assignedTask.getTaskType == ManagerTaskType.CONSULTANT).map(_.assignedTask.asInstanceOf[LevelingManagerTask])
-    val levels = leveling.map(_.level(currentCycle))
+    val levels : Seq[Int] = leveling.map(_.level(currentCycle))
     val best = leveling.sortBy(t => -t.level(currentCycle)).headOption
+    val levelDescription : String = best.map(t => t.levelDescription(currentCycle).toString).getOrElse("—")
     Ok(Json.obj(
       "count" -> leveling.size,
       "maxManagers" -> ConsultantManagerTask.MAX_CONSULTANT_MANAGERS,
       "availableCount" -> managerInfo.availableCount,
       "bestLevel" -> (if (levels.isEmpty) 0 else levels.max),
-      "levelDescription" -> best.map(_.levelDescription(currentCycle)).getOrElse("—"),
+      "levelDescription" -> levelDescription,
       "adviceDepth" -> ConsultantAdvisor.adviceDepth(levels),
       "enabled" -> SoloConfig.consultantEnabled
     ))

--- a/airline-web/app/controllers/NotificationApplication.scala
+++ b/airline-web/app/controllers/NotificationApplication.scala
@@ -1,7 +1,9 @@
 package controllers
 
-import com.patson.data.{CycleSource, NotificationSource}
-import com.patson.model.{Notification, NotificationCategory}
+import com.patson.data.{AirportSource, CountrySource, CycleSource, NotificationSource, SoloConfig}
+import com.patson.data.airplane.AirplaneSource
+import com.patson.model.{ManagerTaskType, LevelingManagerTask, Notification, NotificationCategory}
+import com.patson.ConsultantAdvisor
 import controllers.AuthenticationObject.AuthenticatedAirline
 import javax.inject.Inject
 import play.api.libs.json._
@@ -23,14 +25,45 @@ class NotificationApplication @Inject()(cc: ControllerComponents) extends Abstra
 
   def getNotifications(airlineId: Int) = AuthenticatedAirline(airlineId) { _ =>
     NotificationSource.purgeExpiredByCategory(airlineId, NotificationCategory.NEGOTIATION_LOSS, CycleSource.loadCycle())
-    // WORLD_NEWS has its own News panel; keep it out of the personal bell drawer.
-    val personal = NotificationSource.loadNotificationsByAirline(airlineId).filterNot(_.category == NotificationCategory.WORLD_NEWS)
+    // WORLD_NEWS and CONSULTANT_ADVICE have their own panels; keep them out of the personal bell.
+    val personal = NotificationSource.loadNotificationsByAirline(airlineId)
+      .filterNot(n => n.category == NotificationCategory.WORLD_NEWS || n.category == NotificationCategory.CONSULTANT_ADVICE)
     Ok(Json.toJson(personal))
   }
 
   // World news feed (pull-based, separate from the personal bell).
   def getNews(airlineId: Int) = AuthenticatedAirline(airlineId) { _ =>
     Ok(Json.toJson(NotificationSource.loadByCategory(airlineId, NotificationCategory.WORLD_NEWS, 50)))
+  }
+
+  // Route consultant advice — a pull-based, timestamped list (separate from the bell).
+  def getConsultantAdvice(airlineId: Int) = AuthenticatedAirline(airlineId) { _ =>
+    Ok(Json.toJson(NotificationSource.loadByCategory(airlineId, NotificationCategory.CONSULTANT_ADVICE, 50)))
+  }
+
+  // Regenerate advice: the assigned consultant(s) study the network and replace the stored report,
+  // stamped with the current cycle. Advice-only; nothing is opened.
+  def refreshConsultantAdvice(airlineId: Int) = AuthenticatedAirline(airlineId) { request =>
+    val airline = request.user
+    val currentCycle = CycleSource.loadCycle()
+    val consultants = airline.getManagerInfo().busyManagers.filter(_.assignedTask.getTaskType == ManagerTaskType.CONSULTANT)
+    if (!SoloConfig.consultantEnabled || consultants.isEmpty) {
+      Ok(Json.obj("count" -> 0, "cycle" -> currentCycle))
+    } else {
+      val levels = consultants.map(_.assignedTask.asInstanceOf[LevelingManagerTask].level(currentCycle))
+      val allAirports = AirportSource.loadAllAirports(true)
+      val countryRelationships = CountrySource.getCountryMutualRelationships()
+      val ownedModels = AirplaneSource.loadAirplanesByOwner(airlineId).filterNot(_.isSold).map(_.model).distinct
+      val recs = ConsultantAdvisor.recommendations(airline, levels, allAirports, countryRelationships, ownedModels, currentCycle)
+      NotificationSource.deleteByCategory(airlineId, NotificationCategory.CONSULTANT_ADVICE)
+      val notifications = recs.map { r =>
+        val cfg = s"${r.config.economyVal}Y/${r.config.businessVal}J/${r.config.firstVal}F"
+        val msg = s"Open ${r.from.iata}–${r.to.iata} (${r.distance}km) · ${r.model.name} $cfg · est +$$${r.estWeeklyProfit}/wk"
+        Notification(airlineId = airlineId, category = NotificationCategory.CONSULTANT_ADVICE, message = msg, cycle = currentCycle, targetId = Some(s"${r.from.id}-${r.to.id}"))
+      }
+      if (notifications.nonEmpty) NotificationSource.insertNotificationsBulk(notifications)
+      Ok(Json.obj("count" -> recs.size, "cycle" -> currentCycle))
+    }
   }
 
   def markNewsRead(airlineId: Int) = AuthenticatedAirline(airlineId) { _ =>

--- a/airline-web/app/controllers/NotificationApplication.scala
+++ b/airline-web/app/controllers/NotificationApplication.scala
@@ -1,7 +1,6 @@
 package controllers
 
-import com.patson.data.{AirportSource, CountrySource, CycleSource, NotificationSource, SoloConfig}
-import com.patson.data.airplane.AirplaneSource
+import com.patson.data.{AirplaneSource, AirportSource, CountrySource, CycleSource, NotificationSource, SoloConfig}
 import com.patson.model.{ManagerTaskType, LevelingManagerTask, Notification, NotificationCategory}
 import com.patson.ConsultantAdvisor
 import controllers.AuthenticationObject.AuthenticatedAirline

--- a/airline-web/app/views/fragments/office_canvas.scala.html
+++ b/airline-web/app/views/fragments/office_canvas.scala.html
@@ -495,6 +495,18 @@
                                 View details
                             </button>
                         </div>
+						<div class="section" id="consultantStatus" style="display:none;">
+                            <h4>Route Consultant</h4>
+                            <p class="text-sm" style="opacity:0.8;">Assign managers to study your network and recommend profitable routes &amp; aircraft you may be missing. Advice-only &mdash; nothing is opened for you.</p>
+                            <p class="pb-1">Assigned: <span id="consultantCount">0</span> / <span id="consultantMax">3</span>
+                                &nbsp;<button type="button" class="button" onclick="changeConsultantCount(-1)">&minus;</button>
+                                <button type="button" class="button" onclick="changeConsultantCount(1)">+</button>
+                            </p>
+                            <p class="text-sm pb-1">Level: <span id="consultantLevel">&mdash;</span> &middot; up to <span id="consultantDepth">0</span> recommendations</p>
+                            <button type="button" class="button" onclick="refreshConsultantAdvice()">Refresh advice</button>
+                            <p class="text-sm" id="consultantAsOf" style="opacity:0.7;"></p>
+                            <div id="consultantAdviceList" class="py-2" style="max-height: 320px; overflow-y: auto;"></div>
+                        </div>
 						<div class="section">
                             <h4>Headquarters</h4>
 							<div style="position: relative; height: 125px; width: 150px; margin: auto;box-sizing: border-box;" class="headquartersMap"></div>

--- a/airline-web/conf/routes
+++ b/airline-web/conf/routes
@@ -122,6 +122,8 @@ GET	 	 /airlines/:airlineId/oil-inventory-options		controllers.OilApplication.ge
 POST		 /airlines/:airlineId/set-oil-inventory-option  controllers.OilApplication.setInventoryOption(airlineId : Int, optionId : Int)
 GET		 /airlines/:airlineId/news  controllers.NotificationApplication.getNews(airlineId : Int)
 POST	 /airlines/:airlineId/news/read  controllers.NotificationApplication.markNewsRead(airlineId : Int)
+GET		 /airlines/:airlineId/consultant-advice  controllers.NotificationApplication.getConsultantAdvice(airlineId : Int)
+POST	 /airlines/:airlineId/consultant-advice/refresh  controllers.NotificationApplication.refreshConsultantAdvice(airlineId : Int)
 GET		 /airlines/:airlineId/notifications  controllers.NotificationApplication.getNotifications(airlineId : Int)
 GET		 /airlines/:airlineId/notifications/unread  controllers.NotificationApplication.getUnreadCount(airlineId : Int)
 POST	 /airlines/:airlineId/notifications/read  controllers.NotificationApplication.markAllRead(airlineId : Int)
@@ -201,6 +203,8 @@ POST      /managers/airline/:airlineId/country/:countryCode      controllers.Man
 GET      /managers/airline/:airlineId/aircraft-model/:modelId      controllers.ManagerApplication.getAircraftModelDelegates(modelId: Int, airlineId: Int)
 POST      /managers/airline/:airlineId/aircraft-model/:modelId      controllers.ManagerApplication.updateAircraftModelDelegates(modelId: Int, airlineId: Int)
 GET      /managers/airline/:airlineId/leveling                      controllers.ManagerApplication.getLevelingManagers(airlineId: Int)
+GET      /managers/airline/:airlineId/consultants                   controllers.ManagerApplication.getConsultants(airlineId: Int)
+POST     /managers/airline/:airlineId/consultants                   controllers.ManagerApplication.updateConsultants(airlineId: Int)
 DELETE   /managers/airline/:airlineId/manager/:managerId            controllers.ManagerApplication.deleteManager(airlineId: Int, managerId: Int)
 
 POST		 /santa-claus/guess/:airportId/:airlineId/:difficulty   controllers.ChristmasApplication.makeGuess(airportId : Int, airlineId : Int, difficulty : String)

--- a/airline-web/public/javascripts/office.js
+++ b/airline-web/public/javascripts/office.js
@@ -1502,4 +1502,83 @@ function resetAirline(keepAssets) {
 
 function updateManagerStatus() {
     updateAirlineManagerStatus($('#managerStatus .managerGroups'))
+    loadConsultant()
+}
+
+// ---- Route Consultant (single-player advice-only QOL) ----
+function cycleToYearWeek(cycle) {
+    return "Year " + Math.floor(cycle / 48) + ", Week " + (cycle % 48)
+}
+
+function loadConsultant() {
+    if (typeof activeAirline === 'undefined' || !activeAirline) return
+    $.ajax({
+        type: 'GET',
+        url: "/managers/airline/" + activeAirline.id + "/consultants",
+        success: function(d) {
+            if (!d.enabled) { $('#consultantStatus').hide(); return }
+            $('#consultantStatus').show()
+            $('#consultantCount').text(d.count)
+            $('#consultantMax').text(d.maxManagers)
+            $('#consultantLevel').text(d.count > 0 ? d.levelDescription : '—')
+            $('#consultantDepth').text(d.adviceDepth)
+            $('#consultantStatus').data('available', d.availableCount)
+            loadConsultantAdvice()
+        }
+    })
+}
+
+function changeConsultantCount(delta) {
+    var cur = parseInt($('#consultantCount').text()) || 0
+    var max = parseInt($('#consultantMax').text()) || 0
+    var avail = $('#consultantStatus').data('available') || 0
+    var target = cur + delta
+    if (target < 0 || target > max) return
+    if (delta > 0 && avail < 1) { alert('No available managers — free one up from another task first.'); return }
+    $.ajax({
+        type: 'POST',
+        url: "/managers/airline/" + activeAirline.id + "/consultants",
+        contentType: 'application/json; charset=utf-8',
+        data: JSON.stringify({ managerCount: target }),
+        success: function() { loadConsultant() },
+        error: function(x) { alert(x.responseText || 'Could not update consultants') }
+    })
+}
+
+function refreshConsultantAdvice() {
+    var $btn = $('#consultantStatus button[onclick="refreshConsultantAdvice()"]')
+    $btn.prop('disabled', true).text('Analyzing…')
+    $.ajax({
+        type: 'POST',
+        url: "/airlines/" + activeAirline.id + "/consultant-advice/refresh",
+        success: function() { loadConsultantAdvice() },
+        error: function(x) { alert(x.responseText || 'Could not refresh advice') },
+        complete: function() { $btn.prop('disabled', false).text('Refresh advice') }
+    })
+}
+
+function loadConsultantAdvice() {
+    $.ajax({
+        type: 'GET',
+        url: "/airlines/" + activeAirline.id + "/consultant-advice",
+        success: function(list) { renderConsultantAdvice(list) }
+    })
+}
+
+function renderConsultantAdvice(list) {
+    var $c = $('#consultantAdviceList'); $c.empty()
+    if (!list || list.length === 0) {
+        $('#consultantAsOf').text('')
+        $c.html("<p class='text-sm' style='opacity:0.7;'>No advice yet — assign a consultant, then click Refresh advice.</p>")
+        return
+    }
+    $('#consultantAsOf').text("Advice as of " + cycleToYearWeek(list[0].cycle))
+    list.forEach(function(n) {
+        var stamp = "Yr " + Math.floor(n.cycle / 48) + " Wk " + (n.cycle % 48)
+        $c.append(
+            "<div class='py-1' style='border-bottom:1px solid rgba(255,255,255,0.1);'>" +
+            "<span>" + n.message + "</span> " +
+            "<span class='text-sm' style='opacity:0.55;'>(" + stamp + ")</span></div>"
+        )
+    })
 }


### PR DESCRIPTION
The visible half of the route/fleet consultant (backend in #80). On the **Office page**, a 'Route Consultant' card: assign/unassign managers to the role (cap-enforced, shows level + advice depth), a **Refresh advice** button, and the timestamped recommendation list (Year/Week stamps — a persisted running report, no read/delete). Endpoints: get/updateConsultants (ManagerApplication); refreshConsultantAdvice (runs ConsultantAdvisor, replaces the stored CONSULTANT_ADVICE notifications) + getConsultantAdvice (NotificationApplication); CONSULTANT_ADVICE kept out of the bell. Gated solo.consultant.enabled (default off → card hidden). Web compile-gated on the OptiPlex.

Note: needs a one-off `consultant_delegate_task` table on the live DB before enabling (separate step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)