### PR TITLE
chore(deploy): enable route consultant (solo.consultant.enabled)

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -45,6 +45,7 @@ jobs:
             -Dsolo.news.enabled=true
             -Dsolo.demand.memoize=true
             -Dsolo.progression.enabled=true
+            -Dsolo.consultant.enabled=true
             -Dsolo.alliance.minMembers=2
           # Web process (sign-up + tooltips): starting capital and the same
           # economy display values so tooltips match the simulation.
@@ -57,6 +58,7 @@ jobs:
             -Dsolo.loan.defaultAnnualRate=0.06
             -Dsolo.bankruptcy.cashThreshold=-25000000
             -Dsolo.bankruptcy.assetsThreshold=-150000000
+            -Dsolo.consultant.enabled=true
             -Dsolo.lounge.allowWithoutAlliance=true
             -Dsolo.alliance.minMembers=2
         run: bash scripts/optiplex-deploy.sh


### PR DESCRIPTION
Turns on the route consultant (backend #80, web #81). consultant_delegate_task table already created on the live DB. Flag added to WEB (where the consultant endpoints run) and SIM opts for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)