### PR TITLE
fix(web): align Flights table columns + cleaner consultant advice format

### DIFF
--- a/airline-web/app/controllers/NotificationApplication.scala
+++ b/airline-web/app/controllers/NotificationApplication.scala
@@ -59,8 +59,12 @@ class NotificationApplication @Inject()(cc: ControllerComponents) extends Abstra
       val recs = ConsultantAdvisor.recommendations(airline, levels, allAirports, countryRelationships, ownedModels, fleetByFamily, currentCycle)
       NotificationSource.deleteByCategory(airlineId, NotificationCategory.CONSULTANT_ADVICE)
       val notifications = recs.map { r =>
-        val cfg = s"${r.config.economyVal}Y/${r.config.businessVal}J/${r.config.firstVal}F"
-        val base = s"Open ${r.from.iata}–${r.to.iata} (${r.distance}km) · ${r.model.name} $cfg · est +$$${r.estWeeklyProfit}/wk"
+        val cabin = Seq(
+          if (r.config.economyVal > 0) Some(s"${r.config.economyVal}Y") else None,
+          if (r.config.businessVal > 0) Some(s"${r.config.businessVal}J") else None,
+          if (r.config.firstVal > 0) Some(s"${r.config.firstVal}F") else None
+        ).flatten.mkString(" ")
+        val base = s"${r.from.iata} → ${r.to.iata} · ${f"${r.distance}%,d"} km · ${r.model.name} ($cabin) · ~$$${f"${r.estWeeklyProfit}%,d"}/wk"
         val msg = if (considerCommonality && r.familyInFleet > 0) s"$base · fits your ${r.familyKey} fleet (${r.familyInFleet})" else base
         Notification(airlineId = airlineId, category = NotificationCategory.CONSULTANT_ADVICE, message = msg, cycle = currentCycle, targetId = Some(s"${r.from.id}-${r.to.id}"))
       }

--- a/airline-web/app/views/fragments/links_canvas.scala.html
+++ b/airline-web/app/views/fragments/links_canvas.scala.html
@@ -21,8 +21,6 @@
 						<div class="table-header" id="linksTableSortHeader">
 							<div class="cell" style="width: 3%"><input type="checkbox" id="toggleAllLinks"
 									onclick="toggleAllLinks(this)"></div>
-                            <div class="cell clickable" style="width: 0%" data-sort-property="lastUpdate"
-								data-sort-order="ascending" id="hiddenLinkSortBy"></div>
 							<div class="cell clickable selected" style="width: 16%" data-sort-property="fromAirportCode"
 								data-sort-order="descending" onclick="toggleLinksTableSortOrder($(this))">From Airport
 							</div>
@@ -58,19 +56,17 @@
 							<div class="cell clickable" style="width: 8%" align="right"
 								data-sort-property="profitPerStaff" data-sort-order="ascending"
 								onclick="toggleLinksTableSortOrder($(this))">Profit per staff</div>
-							<div class="cell clickable" style="width: 7%" align="right"
+							<div class="cell clickable" style="width: 7%" align="right" id="hiddenLinkSortBy"
 								data-sort-property="lastUpdate" data-sort-order="descending"
 								onclick="toggleLinksTableSortOrder($(this))" title="When you last edited this route (real time)">Modified</div>
 						</div>
 						<div class="table-header" id="linksTableFilterHeader" style="display: none;">
 							<div class="cell" style="width: 3%">&nbsp;</div>
-                            <div class="cell" style="width: 0%"></div>
 							<div class="cell" style="width: 16%" data-filter-property="fromAirportCode">&nbsp;</div>
 							<div class="cell" style="width: 16%" data-filter-property="toAirportCode">&nbsp;</div>
 							<div class="cell" style="width: 14%" data-filter-property="modelId">&nbsp;</div>
 							<div class="cell" style="width: 8%" data-filter-property="distance">&nbsp;</div>
 							<div class="cell" style="width: 8%">&nbsp;</div>
-							<div class="cell" style="width: 4%">&nbsp;</div>
 							<div class="cell" style="width: 3%">&nbsp;</div>
 							<div class="cell" style="width: 4%">&nbsp;</div>
 							<div class="cell" style="width: 5%">&nbsp;</div>

--- a/airline-web/public/javascripts/office.js
+++ b/airline-web/public/javascripts/office.js
@@ -1575,10 +1575,14 @@ function renderConsultantAdvice(list) {
     $('#consultantAsOf').text("Advice as of " + cycleToYearWeek(list[0].cycle))
     list.forEach(function(n) {
         var stamp = "Yr " + Math.floor(n.cycle / 48) + " Wk " + (n.cycle % 48)
+        var parts = (n.message || '').split(' · ')
+        var route = parts.shift() || n.message
+        var detail = parts.join(' · ')
         $c.append(
             "<div class='py-1' style='border-bottom:1px solid rgba(255,255,255,0.1);'>" +
-            "<span>" + n.message + "</span> " +
-            "<span class='text-sm' style='opacity:0.55;'>(" + stamp + ")</span></div>"
+            "<div><strong>" + route + "</strong> <span class='text-sm' style='opacity:0.5;'>" + stamp + "</span></div>" +
+            "<div class='text-sm' style='opacity:0.8;'>" + detail + "</div>" +
+            "</div>"
         )
     })
 }


### PR DESCRIPTION
Two desktop fixes:

**Flights table alignment** — it's a CSS table, so columns align by cell count/position. The sort header had 16 cells, the filter header 17, the data rows 15 (a hidden 0%-width lastUpdate sort cell + a stray filter cell). My Modified column made the off-by-one visibly misaligned on desktop (Framework 13). Normalized everything to **15 matching columns**: dropped the hidden cell (moved its `hiddenLinkSortBy` id onto the visible Modified column so the clock-sort still works) and rebuilt the filter header.

**Advice format** — bold route + Year/Week stamp on line 1, lighter details (distance · aircraft (cabin) · ~$profit/wk · commonality) on line 2; comma-separated numbers, zero cabin classes omitted, → arrow.

Compile-gated (web). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)