### PR TITLE
fix(web): align Flights body column widths to the Modified column

### DIFF
--- a/airline-web/app/views/fragments/links_canvas.scala.html
+++ b/airline-web/app/views/fragments/links_canvas.scala.html
@@ -95,6 +95,7 @@
 								<div class="cell" style="width: 7%; border-bottom: none;"></div>
 								<div class="cell" style="width: 6%; border-bottom: none;"></div>
 								<div class="cell" style="width: 8%; border-bottom: none;"></div>
+								<div class="cell" style="width: 7%; border-bottom: none;"></div>
 							</div>
 						</div>
 						<div style="height: 100px; width: 100%; min-width: 600px; display:none;" class="noLinkTips">


### PR DESCRIPTION
Follow-up to #84: the #linksTable body has its own hidden width-defining header (sizes the body columns) that still had 14 cells — missing the Modified column — so the 15th data cell drifted ~83px from its sort-header column on desktop. Added the missing 15th width cell. All four structures now have 15 matching columns. DOM-verified (cell counts + last-column left-edge delta).