### PR TITLE
fix(web): redirect logged-in users away from blank /login/

### DIFF
--- a/airline-web/public/javascripts/routes.js
+++ b/airline-web/public/javascripts/routes.js
@@ -67,6 +67,11 @@ function initializeRoutes() {
     });
 
     page('/login/', () => {
+        // Already logged in? Don't show a dead login screen over the app chrome — go to the app.
+        if (checkSessionGuard()) {
+            page.redirect('/map/');
+            return;
+        }
         document.title = 'Login';
         showLoginPage();
     });


### PR DESCRIPTION
A logged-in user on /login/ saw a blank canvas (game chrome from the session, but showLoginPage() activates no game canvas). Now /login/ redirects to /map/ when a valid session exists. Reproduced: logged in -> goto /login/ -> activeCanvas '(none visible)'.