### PR TITLE
fix(web): deploy-unique index HTML ETag — stop serving stale cached JS

### DIFF
--- a/airline-web/app/controllers/Application.scala
+++ b/airline-web/app/controllers/Application.scala
@@ -134,16 +134,23 @@ class Application @Inject()(cc: ControllerComponents, val configuration: play.ap
     }
   }
 
+  // Deploy-unique ETag for the index HTML. The HTML embeds the fingerprinted asset map, so it
+  // changes every build — but the old ETag was the static app version ("v5.1.2"), which never
+  // changed between deploys. With Cache-Control: no-cache the browser revalidates, the static ETag
+  // always matched → 304 → the browser kept the OLD HTML (and thus loaded OLD JS) forever. Keying
+  // the ETag to the JVM start time makes each deploy (new process) invalidate the cached HTML.
+  private val indexEtag: String = s""""build-${java.lang.management.ManagementFactory.getRuntimeMXBean.getStartTime}""""
+
   // path parameter is captured but ignored - page.js handles routing
   def index(path: String = "") = Action { implicit request =>
     implicit lazy val config = configuration
     request.headers.get(IF_NONE_MATCH) match {
-      case Some(etag) if etag == s""""$currentApiVersion"""" =>
+      case Some(etag) if etag == indexEtag =>
         NotModified
       case _ =>
         Ok(views.html.index()).withHeaders(
           CACHE_CONTROL -> "no-cache",
-          ETAG -> s""""$currentApiVersion""""
+          ETAG -> indexEtag
         )
     }
   }


### PR DESCRIPTION
**Root cause of the cascade of 'feature X is broken' reports** (login, then route creation, …). The index HTML had a static ETag = the app version (`"v5.1.2"`) with `Cache-Control: no-cache`. no-cache forces revalidation, but the static ETag never changed between deploys → the server always returned 304 → the browser kept the OLD cached HTML, which embeds the fingerprinted asset map → it loaded OLD JS forever. So none of my deploys actually reached the user; each new feature broke because they ran stale code against a new server.

**Fix:** key the index ETag to the JVM start time, so each deploy (new process) produces a new ETag → the browser's revalidation returns 200 with fresh HTML + current assets. No manual cache-clearing needed on the user's side. Compile-gated.