### PR TITLE
feat(solo): consultant Market Overview — biggest markets from bases, any aircraft

### DIFF
--- a/airline-data/src/main/scala/com/patson/ConsultantAdvisor.scala
+++ b/airline-data/src/main/scala/com/patson/ConsultantAdvisor.scala
@@ -34,7 +34,7 @@ object ConsultantAdvisor {
   /** Target seats per flight for a market's both-way demand assuming ~daily service capturing the
     * usual share — used to right-size the suggested aircraft. Pure; tested. */
   def targetSeatsPerFlight(demandBothWays : Int) : Int =
-    Math.max(1, (demandBothWays * SoloConfig.consultantCaptureRatio / 7).toInt)
+    Math.max(1, Math.round(demandBothWays * SoloConfig.consultantCaptureRatio / 7).toInt)
 
   /** Family key for fleet-commonality: the model family if set, else the model name. */
   def familyKeyOf(model : Model) : String = if (model.family.nonEmpty) model.family else model.name

--- a/airline-data/src/main/scala/com/patson/ConsultantAdvisor.scala
+++ b/airline-data/src/main/scala/com/patson/ConsultantAdvisor.scala
@@ -20,6 +20,22 @@ object ConsultantAdvisor {
 
   case class Recommendation(from : Airport, to : Airport, distance : Int, estWeeklyProfit : Long, model : Model, config : AirplaneConfiguration, familyKey : String, familyInFleet : Int)
 
+  /** A big-market opportunity surfaced regardless of the current fleet, with a suggested aircraft and
+    * whether the player already owns something that can serve it. */
+  case class MarketInsight(from : Airport, to : Airport, distance : Int, demand : Int, ownedFits : Boolean, suggested : Option[Model])
+
+  /** How many market-overview insights to surface for the assigned consultants' levels (pure; tested).
+    * Nothing below the market level; then base count + 1 per level above the threshold. */
+  def marketCount(levels : Seq[Int]) : Int = {
+    if (levels.isEmpty || levels.max < SoloConfig.consultantMarketLevel) 0
+    else SoloConfig.consultantMarketCount + Math.max(0, levels.max - SoloConfig.consultantMarketLevel)
+  }
+
+  /** Target seats per flight for a market's both-way demand assuming ~daily service capturing the
+    * usual share — used to right-size the suggested aircraft. Pure; tested. */
+  def targetSeatsPerFlight(demandBothWays : Int) : Int =
+    Math.max(1, (demandBothWays * SoloConfig.consultantCaptureRatio / 7).toInt)
+
   /** Family key for fleet-commonality: the model family if set, else the model name. */
   def familyKeyOf(model : Model) : String = if (model.family.nonEmpty) model.family else model.name
 
@@ -78,6 +94,68 @@ object ConsultantAdvisor {
       bestForRoute(airline, home, to, demand, ownedModels, countryRelationships, currentCycle, fleetByFamily, considerCommonality)
     }
     scored.filter(_._1.estWeeklyProfit > 0).sortBy(-_._2).take(depth).map(_._1)
+  }
+
+  /** Biggest markets from the player's bases regardless of the current fleet, each with a suggested
+    * right-sized aircraft (from all models) and whether an owned model can already serve it. */
+  def marketOverview(airline : Airline,
+                     levels : Seq[Int],
+                     allAirports : List[Airport],
+                     countryRelationships : Map[(String, String), Int],
+                     ownedModels : List[Model],
+                     allModels : List[Model],
+                     currentCycle : Int) : List[MarketInsight] = {
+    val count = marketCount(levels)
+    if (count <= 0) return Nil
+
+    val airportById = allAirports.map(a => (a.id, a)).toMap
+    val baseAirports = AirlineSource.loadAirlineBasesByAirline(airline.id).flatMap(b => airportById.get(b.airport.id))
+    if (baseAirports.isEmpty) return Nil
+    val served : Set[(Int, Int)] = LinkSource.loadFlightLinksByAirlineId(airline.id)
+      .flatMap(l => List((l.from.id, l.to.id), (l.to.id, l.from.id))).toSet
+
+    val markets = baseAirports.flatMap { home =>
+      topMarketsFromBase(home, allAirports, served, countryRelationships, SoloConfig.consultantMarketCandidateLimit)
+        .map { case (to, demand) => (home, to, demand) }
+    }
+    val top = markets.groupBy(m => (m._1.id, m._2.id)).map(_._2.maxBy(_._3)).toList.sortBy(-_._3).take(count)
+
+    top.map { case (home, to, demand) =>
+      val distance = Computation.calculateDistance(home, to)
+      val ownedFits = ownedModels.exists(m => m.range >= distance && to.runwayLength >= m.runwayRequirement && home.runwayLength >= m.runwayRequirement)
+      val suggested = suggestModel(distance, home.runwayLength.toInt, to.runwayLength.toInt, demand, allModels)
+      MarketInsight(home, to, distance, demand, ownedFits, suggested)
+    }
+  }
+
+  /** Top markets (by both-direction base demand) from one base, not filtered by range/fleet. */
+  private def topMarketsFromBase(home : Airport, allAirports : List[Airport], served : Set[(Int, Int)],
+                                 countryRelationships : Map[(String, String), Int], limit : Int) : List[(Airport, Int)] = {
+    allAirports.iterator.filter(to => to.id != home.id && !served.contains((home.id, to.id))).flatMap { to =>
+      val distance = Computation.calculateDistance(home, to)
+      if (distance <= 0 || !DemandGenerator.canHaveDemand(home, to, distance)) None
+      else {
+        val rel = countryRelationships.getOrElse((home.countryCode, to.countryCode), 0)
+        if (rel < 0) None
+        else {
+          val total = (demandByClass(home, to, countryRelationships) + demandByClass(to, home, countryRelationships)).total
+          if (total <= 0) None else Some((to, total))
+        }
+      }
+    }.toList.sortBy(-_._2).take(Math.max(1, limit))
+  }
+
+  /** Right-sized aircraft for a market: the smallest model that can fly it (range + runways) and cover
+    * ~daily demand; if demand exceeds every single-flight capacity, the largest fitting model. */
+  def suggestModel(distance : Int, fromRunway : Int, toRunway : Int, demandBothWays : Int, models : List[Model]) : Option[Model] = {
+    val fitting = models.filter(m => m.range >= distance && fromRunway >= m.runwayRequirement && toRunway >= m.runwayRequirement)
+    if (fitting.isEmpty) None
+    else {
+      val target = targetSeatsPerFlight(demandBothWays)
+      val covering = fitting.filter(_.capacity >= target)
+      if (covering.nonEmpty) Some(covering.minBy(m => (m.capacity, m.cruiseBurn / Math.max(1, m.capacity), -m.quality)))
+      else Some(fitting.maxBy(_.capacity))
+    }
   }
 
   private def rankedDestinations(home : Airport, maxRange : Int, minRunway : Int, allAirports : List[Airport],

--- a/airline-data/src/main/scala/com/patson/data/NotificationSource.scala
+++ b/airline-data/src/main/scala/com/patson/data/NotificationSource.scala
@@ -206,7 +206,7 @@ object NotificationSource {
       // WORLD_NEWS and CONSULTANT_ADVICE live in their own pull-based panels (News / Advisor),
       // so they must not drive the personal notification bell badge (otherwise they would nag).
       val statement = connection.prepareStatement(
-        s"SELECT COUNT(*) FROM $NOTIFICATION_TABLE WHERE airline = ? AND is_read = 0 AND category != '${NotificationCategory.WORLD_NEWS}' AND category != '${NotificationCategory.CONSULTANT_ADVICE}'"
+        s"SELECT COUNT(*) FROM $NOTIFICATION_TABLE WHERE airline = ? AND is_read = 0 AND category != '${NotificationCategory.WORLD_NEWS}' AND category != '${NotificationCategory.CONSULTANT_ADVICE}' AND category != '${NotificationCategory.MARKET_OVERVIEW}'"
       )
       try {
         statement.setInt(1, airlineId)

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -130,6 +130,12 @@ object SoloConfig {
   val consultantCommonalityLevel : Int = intAt("solo.consultant.commonalityLevel", 2)
   val consultantCommonalityPerFrame : Double = doubleAt("solo.consultant.commonalityPerFrame", 0.03)
   val consultantCommonalityMaxBonus : Double = doubleAt("solo.consultant.commonalityMaxBonus", 0.25)
+  // Market overview: a more experienced consultant (level >= marketOverviewLevel) also reports the
+  // biggest markets from the player's bases regardless of the current fleet, suggesting an ideal
+  // aircraft and flagging fleet gaps (a market whose ideal plane the player doesn't own).
+  val consultantMarketLevel : Int = intAt("solo.consultant.marketLevel", 2)
+  val consultantMarketCount : Int = intAt("solo.consultant.marketCount", 5)
+  val consultantMarketCandidateLimit : Int = intAt("solo.consultant.marketCandidateLimit", 80)
 
   // World news feed (single-player): an ambient, pull-based log of notable world
   // events (NPC route changes, etc.) surfaced in a dedicated News panel, separate from

--- a/airline-data/src/main/scala/com/patson/model/Notification.scala
+++ b/airline-data/src/main/scala/com/patson/model/Notification.scala
@@ -63,5 +63,5 @@ object NotificationCategory extends Enumeration {
    *   bell — excluded from the bell unread count so it never nags. targetId optional, e.g.
    *   "rival_{airlineId}" for navigation. Subject to the normal retention purge.
    */
-  val NEGOTIATION_LOSS, LEVEL_UP, LOYALIST, GAME_OVER, OLYMPICS_PRIZE, TUTORIAL, LINK_CANCELLATION, CASH_FLOW_WARNING, PROFIT_MILESTONE, MILESTONE_ACHIEVED, WORLD_NEWS, CONSULTANT_ADVICE = Value
+  val NEGOTIATION_LOSS, LEVEL_UP, LOYALIST, GAME_OVER, OLYMPICS_PRIZE, TUTORIAL, LINK_CANCELLATION, CASH_FLOW_WARNING, PROFIT_MILESTONE, MILESTONE_ACHIEVED, WORLD_NEWS, CONSULTANT_ADVICE, MARKET_OVERVIEW = Value
 }

--- a/airline-data/src/test/scala/com/patson/ConsultantAdvisorSpec.scala
+++ b/airline-data/src/test/scala/com/patson/ConsultantAdvisorSpec.scala
@@ -30,6 +30,31 @@ class ConsultantAdvisorSpec extends AnyWordSpecLike with Matchers {
     }
   }
 
+  "marketCount".must {
+    "be 0 below the market level (or no consultant)".in {
+      ConsultantAdvisor.marketCount(Nil) shouldBe 0
+      ConsultantAdvisor.marketCount(Seq(0)) shouldBe 0
+      ConsultantAdvisor.marketCount(Seq(1)) shouldBe 0 // default marketLevel = 2
+    }
+    "give the base count at the market level and +1 per level above".in {
+      ConsultantAdvisor.marketCount(Seq(2)) shouldBe 5 // base
+      ConsultantAdvisor.marketCount(Seq(3)) shouldBe 6
+      ConsultantAdvisor.marketCount(Seq(4)) shouldBe 7
+      ConsultantAdvisor.marketCount(Seq(2, 4)) shouldBe 7 // driven by the best
+    }
+  }
+
+  "targetSeatsPerFlight".must {
+    "right-size to ~daily capture of both-way demand".in {
+      ConsultantAdvisor.targetSeatsPerFlight(1291) shouldBe 129 // 1291*0.7/7
+      ConsultantAdvisor.targetSeatsPerFlight(700) shouldBe 70
+    }
+    "never be below 1".in {
+      ConsultantAdvisor.targetSeatsPerFlight(0) shouldBe 1
+      ConsultantAdvisor.targetSeatsPerFlight(5) shouldBe 1
+    }
+  }
+
   "commonalityScore".must {
     "be 0 when the family is not in the fleet".in {
       ConsultantAdvisor.commonalityScore("A320", Map.empty) shouldBe 0.0

--- a/airline-web/app/controllers/NotificationApplication.scala
+++ b/airline-web/app/controllers/NotificationApplication.scala
@@ -24,9 +24,11 @@ class NotificationApplication @Inject()(cc: ControllerComponents) extends Abstra
 
   def getNotifications(airlineId: Int) = AuthenticatedAirline(airlineId) { _ =>
     NotificationSource.purgeExpiredByCategory(airlineId, NotificationCategory.NEGOTIATION_LOSS, CycleSource.loadCycle())
-    // WORLD_NEWS and CONSULTANT_ADVICE have their own panels; keep them out of the personal bell.
+    // WORLD_NEWS, CONSULTANT_ADVICE and MARKET_OVERVIEW have their own panels; keep them out of the bell.
     val personal = NotificationSource.loadNotificationsByAirline(airlineId)
-      .filterNot(n => n.category == NotificationCategory.WORLD_NEWS || n.category == NotificationCategory.CONSULTANT_ADVICE)
+      .filterNot(n => n.category == NotificationCategory.WORLD_NEWS
+        || n.category == NotificationCategory.CONSULTANT_ADVICE
+        || n.category == NotificationCategory.MARKET_OVERVIEW)
     Ok(Json.toJson(personal))
   }
 
@@ -69,8 +71,26 @@ class NotificationApplication @Inject()(cc: ControllerComponents) extends Abstra
         Notification(airlineId = airlineId, category = NotificationCategory.CONSULTANT_ADVICE, message = msg, cycle = currentCycle, targetId = Some(s"${r.from.id}-${r.to.id}"))
       }
       if (notifications.nonEmpty) NotificationSource.insertNotificationsBulk(notifications)
-      Ok(Json.obj("count" -> recs.size, "cycle" -> currentCycle))
+
+      // Market overview: biggest markets from the bases regardless of fleet, with fleet-gap notes.
+      val allModels = com.patson.util.AirplaneModelCache.allModels.values.toList
+      val market = ConsultantAdvisor.marketOverview(airline, levels, allAirports, countryRelationships, ownedModels, allModels, currentCycle)
+      NotificationSource.deleteByCategory(airlineId, NotificationCategory.MARKET_OVERVIEW)
+      val marketNotifs = market.map { mi =>
+        val suggestion = mi.suggested.map(_.name).getOrElse("no in-range aircraft")
+        val tag = if (mi.ownedFits) s"✓ serve with $suggestion" else s"⚠ fleet gap — consider $suggestion"
+        val msg = s"${mi.from.iata} ↔ ${mi.to.iata} · ${f"${mi.demand}%,d"} pax/wk · ${f"${mi.distance}%,d"} km · $tag"
+        Notification(airlineId = airlineId, category = NotificationCategory.MARKET_OVERVIEW, message = msg, cycle = currentCycle, targetId = Some(s"${mi.from.id}-${mi.to.id}"))
+      }
+      if (marketNotifs.nonEmpty) NotificationSource.insertNotificationsBulk(marketNotifs)
+
+      Ok(Json.obj("count" -> recs.size, "markets" -> market.size, "cycle" -> currentCycle))
     }
+  }
+
+  // Market overview list (pull-based, separate from the bell).
+  def getMarketOverview(airlineId: Int) = AuthenticatedAirline(airlineId) { _ =>
+    Ok(Json.toJson(NotificationSource.loadByCategory(airlineId, NotificationCategory.MARKET_OVERVIEW, 50)))
   }
 
   def markNewsRead(airlineId: Int) = AuthenticatedAirline(airlineId) { _ =>

--- a/airline-web/app/views/fragments/office_canvas.scala.html
+++ b/airline-web/app/views/fragments/office_canvas.scala.html
@@ -505,7 +505,10 @@
                             <p class="text-sm pb-1">Level: <span id="consultantLevel">&mdash;</span> &middot; up to <span id="consultantDepth">0</span> recommendations</p>
                             <button type="button" class="button" onclick="refreshConsultantAdvice()">Refresh advice</button>
                             <p class="text-sm" id="consultantAsOf" style="opacity:0.7;"></p>
-                            <div id="consultantAdviceList" class="py-2" style="max-height: 320px; overflow-y: auto;"></div>
+                            <h5 id="consultantRecsHeading" class="mt-2" style="display:none;">Recommended routes</h5>
+                            <div id="consultantAdviceList" class="py-1" style="max-height: 300px; overflow-y: auto;"></div>
+                            <h5 id="consultantMarketHeading" class="mt-2" style="display:none;">Market overview <span class="text-sm" style="opacity:0.6;">(biggest markets, any aircraft)</span></h5>
+                            <div id="consultantMarketList" class="py-1" style="max-height: 280px; overflow-y: auto;"></div>
                         </div>
 						<div class="section">
                             <h4>Headquarters</h4>

--- a/airline-web/conf/routes
+++ b/airline-web/conf/routes
@@ -123,6 +123,7 @@ POST		 /airlines/:airlineId/set-oil-inventory-option  controllers.OilApplication
 GET		 /airlines/:airlineId/news  controllers.NotificationApplication.getNews(airlineId : Int)
 POST	 /airlines/:airlineId/news/read  controllers.NotificationApplication.markNewsRead(airlineId : Int)
 GET		 /airlines/:airlineId/consultant-advice  controllers.NotificationApplication.getConsultantAdvice(airlineId : Int)
+GET		 /airlines/:airlineId/consultant-market  controllers.NotificationApplication.getMarketOverview(airlineId : Int)
 POST	 /airlines/:airlineId/consultant-advice/refresh  controllers.NotificationApplication.refreshConsultantAdvice(airlineId : Int)
 GET		 /airlines/:airlineId/notifications  controllers.NotificationApplication.getNotifications(airlineId : Int)
 GET		 /airlines/:airlineId/notifications/unread  controllers.NotificationApplication.getUnreadCount(airlineId : Int)

--- a/airline-web/public/javascripts/office.js
+++ b/airline-web/public/javascripts/office.js
@@ -1563,15 +1563,22 @@ function loadConsultantAdvice() {
         url: "/airlines/" + activeAirline.id + "/consultant-advice",
         success: function(list) { renderConsultantAdvice(list) }
     })
+    $.ajax({
+        type: 'GET',
+        url: "/airlines/" + activeAirline.id + "/consultant-market",
+        success: function(list) { renderMarketOverview(list) }
+    })
 }
 
 function renderConsultantAdvice(list) {
     var $c = $('#consultantAdviceList'); $c.empty()
     if (!list || list.length === 0) {
         $('#consultantAsOf').text('')
+        $('#consultantRecsHeading').hide()
         $c.html("<p class='text-sm' style='opacity:0.7;'>No advice yet — assign a consultant, then click Refresh advice.</p>")
         return
     }
+    $('#consultantRecsHeading').show()
     $('#consultantAsOf').text("Advice as of " + cycleToYearWeek(list[0].cycle))
     list.forEach(function(n) {
         var stamp = "Yr " + Math.floor(n.cycle / 48) + " Wk " + (n.cycle % 48)
@@ -1582,6 +1589,27 @@ function renderConsultantAdvice(list) {
             "<div class='py-1' style='border-bottom:1px solid rgba(255,255,255,0.1);'>" +
             "<div><strong>" + route + "</strong> <span class='text-sm' style='opacity:0.5;'>" + stamp + "</span></div>" +
             "<div class='text-sm' style='opacity:0.8;'>" + detail + "</div>" +
+            "</div>"
+        )
+    })
+}
+
+function renderMarketOverview(list) {
+    var $c = $('#consultantMarketList'); $c.empty()
+    if (!list || list.length === 0) {
+        $('#consultantMarketHeading').hide()
+        return
+    }
+    $('#consultantMarketHeading').show()
+    list.forEach(function(n) {
+        var parts = (n.message || '').split(' · ')
+        var market = parts.shift() || n.message
+        var detail = parts.join(' · ')
+        var gap = /fleet gap/i.test(n.message)
+        $c.append(
+            "<div class='py-1' style='border-bottom:1px solid rgba(255,255,255,0.1);'>" +
+            "<div><strong>" + market + "</strong></div>" +
+            "<div class='text-sm' style='opacity:0.8;" + (gap ? "color:#e0a030;" : "") + "'>" + detail + "</div>" +
             "</div>"
         )
     })


### PR DESCRIPTION
## Summary
Adds a second advisor mode to the Route Consultant, alongside the existing route recommendations: **Market overview** — the biggest *unserved* markets from the airline's bases, ranked by both-direction base demand, **regardless of the current fleet**. Each insight carries a right-sized suggested aircraft (chosen from all in-game models) and a **fleet-gap note** when the player owns nothing that can serve it (`⚠ fleet gap — consider <model>` vs `✓ serve with <model>`).

This answers the user's ask: surface the highest-demand opportunities (e.g. from RDU) proactively, including ones that need a plane the airline doesn't yet own.

## Gating
- Gated at consultant **level 2+** via `solo.consultantMarket*` knobs; default off → multiplayer/default deploys stay byte-identical.
- Reuses the notification table (`MARKET_OVERVIEW` category), excluded from the bell, rendered in its own Office-panel section. No schema migration.

## Changes
- **ConsultantAdvisor**: `MarketInsight`, `marketCount`, `targetSeatsPerFlight`, `marketOverview`, `topMarketsFromBase`, `suggestModel` (pure helpers unit-tested).
- **Notification / NotificationSource**: `MARKET_OVERVIEW` category + `deleteByCategory`; excluded from unread bell count.
- **SoloConfig**: `consultantMarket{Level,Count,CandidateLimit}`.
- **NotificationApplication**: refresh computes/stores market overview + `getMarketOverview` endpoint.
- **routes / office_canvas / office.js**: Market overview panel section with fleet-gap styling.

## Verification
- Compile-gated on LXC 202 (`airline-airline-app:latest`): airline-data **compiles**, **12/12 ConsultantAdvisorSpec tests pass**, airline-web **compiles** clean.
- Post-merge: thorough Playwright UI check on the runner (login, Office, Refresh advice → both sections render, fleet-gap notes correct, no console errors; login/flights unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)