### PR TITLE
fix(solo): rank market-overview aircraft by per-seat efficiency, not smallest

### DIFF
--- a/airline-data/src/main/scala/com/patson/ConsultantAdvisor.scala
+++ b/airline-data/src/main/scala/com/patson/ConsultantAdvisor.scala
@@ -145,16 +145,23 @@ object ConsultantAdvisor {
     }.toList.sortBy(-_._2).take(Math.max(1, limit))
   }
 
-  /** Right-sized aircraft for a market: the smallest model that can fly it (range + runways) and cover
-    * ~daily demand; if demand exceeds every single-flight capacity, the largest fitting model. */
+  /** Right-sized aircraft for a market: among models that can fly it (range + runways) and cover
+    * ~daily demand, prefer the most fuel-efficient per seat within a right-sized capacity band (so a
+    * thirsty antique/piston that merely has the range loses to a modern jet of similar size), then the
+    * higher-quality one. If demand exceeds every single-flight capacity, the largest fitting model. */
   def suggestModel(distance : Int, fromRunway : Int, toRunway : Int, demandBothWays : Int, models : List[Model]) : Option[Model] = {
     val fitting = models.filter(m => m.range >= distance && fromRunway >= m.runwayRequirement && toRunway >= m.runwayRequirement)
     if (fitting.isEmpty) None
     else {
       val target = targetSeatsPerFlight(demandBothWays)
       val covering = fitting.filter(_.capacity >= target)
-      if (covering.nonEmpty) Some(covering.minBy(m => (m.capacity, m.cruiseBurn / Math.max(1, m.capacity), -m.quality)))
-      else Some(fitting.maxBy(_.capacity))
+      if (covering.isEmpty) Some(fitting.maxBy(_.capacity))
+      else {
+        // Stay close to demand (avoid oversizing) but, within that band, pick the best economics.
+        val band = covering.filter(_.capacity <= target * 2)
+        val candidates = if (band.nonEmpty) band else covering
+        Some(candidates.minBy(m => (m.cruiseBurn.toDouble / Math.max(1, m.capacity), -m.quality)))
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Follow-up polish to the consultant Market Overview (#89). Live UI check showed the suggested aircraft were not credible — e.g. a **1947 Lockheed L-749 Constellation** for RDU↔YYC (3,262 km) and RDU↔PTY (2,981 km) — because `suggestModel` sorted in-range covering models by **smallest capacity first**, which favors antiques/regional types that merely have the range.

Now ranks covering models by **fuel burn per seat** within a right-sized capacity band (`target..2×target`), then by quality, so a thirsty piston loses to a modern jet of similar size. Unchanged fallback: largest fitting model only when demand exceeds every single-flight capacity.

## Verification
- Compile-gated on LXC 202: airline-data compiles, **12/12 ConsultantAdvisorSpec pass**, airline-web compiles.
- Post-merge: re-run the live UI check to confirm the Market overview now suggests sensible modern aircraft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)