### PR TITLE
fix(solo): rank suggested aircraft by fuel-per-seat-km (drop airship/antique picks)

### DIFF
--- a/airline-data/src/main/scala/com/patson/ConsultantAdvisor.scala
+++ b/airline-data/src/main/scala/com/patson/ConsultantAdvisor.scala
@@ -145,10 +145,15 @@ object ConsultantAdvisor {
     }.toList.sortBy(-_._2).take(Math.max(1, limit))
   }
 
+  /** Fuel per available seat-km (the standard airline efficiency metric). Lower is better. Rewards
+    * modern efficient jets and penalizes both thirsty antiques (high burn) and impractically slow
+    * novelty types like airships (near-zero burn swamped by near-zero speed). */
+  private def fuelPerSeatKm(m : Model) : Double = m.cruiseBurn.toDouble / Math.max(1, m.capacity * m.speed)
+
   /** Right-sized aircraft for a market: among models that can fly it (range + runways) and cover
-    * ~daily demand, prefer the most fuel-efficient per seat within a right-sized capacity band (so a
-    * thirsty antique/piston that merely has the range loses to a modern jet of similar size), then the
-    * higher-quality one. If demand exceeds every single-flight capacity, the largest fitting model. */
+    * ~daily demand, prefer the best fuel-per-seat-km within a right-sized capacity band (target..2x),
+    * then the higher-quality one — so a thirsty antique or a too-slow airship loses to a modern jet of
+    * similar size. If demand exceeds every single-flight capacity, the largest fitting model. */
   def suggestModel(distance : Int, fromRunway : Int, toRunway : Int, demandBothWays : Int, models : List[Model]) : Option[Model] = {
     val fitting = models.filter(m => m.range >= distance && fromRunway >= m.runwayRequirement && toRunway >= m.runwayRequirement)
     if (fitting.isEmpty) None
@@ -160,7 +165,7 @@ object ConsultantAdvisor {
         // Stay close to demand (avoid oversizing) but, within that band, pick the best economics.
         val band = covering.filter(_.capacity <= target * 2)
         val candidates = if (band.nonEmpty) band else covering
-        Some(candidates.minBy(m => (m.cruiseBurn.toDouble / Math.max(1, m.capacity), -m.quality)))
+        Some(candidates.minBy(m => (fuelPerSeatKm(m), -m.quality)))
       }
     }
   }


### PR DESCRIPTION
## Summary
Second follow-up to the Market Overview (#89, #90). Ranking suggested aircraft by raw burn-per-seat (#90) over-corrected: it then surfaced **Zeppelin airships** and hydrogen concepts, whose near-zero fuel burn won despite being far too slow to realistically serve the route.

Switch to **fuel per available seat-km** — `cruiseBurn / (capacity × speed)`, the standard airline efficiency metric. An airship's near-zero burn is swamped by its near-zero speed, so it drops out; thirsty antiques also lose to modern jets of similar size. Right-sized capacity band and largest-fitting fallback unchanged.

## Verification
- Compile-gated on LXC 202: data compiles, 12/12 spec pass, web compiles.
- Live UI check confirmed (pre-merge, on the burn-per-seat build) the egregious 1947 Constellation pick was already gone; this lands the airship correction. Post-merge re-check to confirm all six suggestions are mainstream aircraft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)