### PR TITLE
fix(solo): exclude impractically slow novelty aircraft (airships) from suggestions

### DIFF
--- a/airline-data/src/main/scala/com/patson/ConsultantAdvisor.scala
+++ b/airline-data/src/main/scala/com/patson/ConsultantAdvisor.scala
@@ -17,6 +17,9 @@ import com.patson.model.airplane.{Airplane, AirplaneConfiguration, LinkAssignmen
   */
 object ConsultantAdvisor {
   private val SEAT_TARGET_MULTIPLIER = 1.5
+  // Floor to exclude impractical novelty types (airships ~100-135 km/h) from aircraft suggestions;
+  // every real commercial aircraft, turboprops included, cruises well above this.
+  private val MIN_PRACTICAL_SPEED_KPH = 300
 
   case class Recommendation(from : Airport, to : Airport, distance : Int, estWeeklyProfit : Long, model : Model, config : AirplaneConfiguration, familyKey : String, familyInFleet : Int)
 
@@ -155,7 +158,7 @@ object ConsultantAdvisor {
     * then the higher-quality one — so a thirsty antique or a too-slow airship loses to a modern jet of
     * similar size. If demand exceeds every single-flight capacity, the largest fitting model. */
   def suggestModel(distance : Int, fromRunway : Int, toRunway : Int, demandBothWays : Int, models : List[Model]) : Option[Model] = {
-    val fitting = models.filter(m => m.range >= distance && fromRunway >= m.runwayRequirement && toRunway >= m.runwayRequirement)
+    val fitting = models.filter(m => m.speed >= MIN_PRACTICAL_SPEED_KPH && m.range >= distance && fromRunway >= m.runwayRequirement && toRunway >= m.runwayRequirement)
     if (fitting.isEmpty) None
     else {
       val target = targetSeatsPerFlight(demandBothWays)


### PR DESCRIPTION
## Summary
Final follow-up to the Market Overview aircraft-suggestion quality (#89/#90/#91). Even fuel-per-seat-km couldn't dislodge **Zeppelin airships** — the game models their fuel burn as near-zero, swamping any speed penalty in an efficiency ratio.

An airship's real disqualifier is that it's far too slow for a commercial route, so filter suggestion candidates by a practical cruise-speed floor (300 km/h). Airships (~100–135 km/h) drop out; every real commercial aircraft, turboprops included, clears it comfortably. Efficiency ranking + right-sizing unchanged.

## Verification
- Compile-gated on LXC 202: data compiles, 12/12 spec pass, web compiles.
- Post-merge: live UI check to confirm all six market suggestions are mainstream commercial aircraft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)