### PR TITLE
feat(solo): notify when route negotiations are ready

### DIFF
--- a/.github/workflows/optiplex-deploy.yml
+++ b/.github/workflows/optiplex-deploy.yml
@@ -52,6 +52,7 @@ jobs:
             -Dsolo.bankruptcy.cashThreshold=-25000000
             -Dsolo.bankruptcy.assetsThreshold=-150000000
             -Dsolo.notify.enabled=true
+            -Dsolo.negotiationReady.enabled=true
             -Dsolo.ai.enabled=true
             -Dsolo.ai.growth.enabled=true
             -Dsolo.ai.pricetune.enabled=true

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 node_modules
 e2e/test-results/
 e2e/playwright-report/
+e2e/ui-*.mjs
+airline-web/*.log

--- a/airline-data/src/main/scala/com/patson/AirlineSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/AirlineSimulation.scala
@@ -37,6 +37,7 @@ object AirlineSimulation {
     println(s"Loaded ${allLinks.length} links")
     //purge old ledger entries
     AirlineSource.deleteLedgerEntries(cycle - BOOKKEEPING_ENTRIES_COUNT)
+    NegotiationReadyNotifier.emit(cycle)
 
     val flightLinkResultByAirline = flightLinkResult.groupBy(_.link.airline.id)
     println(s"Loaded ${flightLinkResultByAirline.size} airline lists of flight consumptions")

--- a/airline-data/src/main/scala/com/patson/NegotiationReadyNotifier.scala
+++ b/airline-data/src/main/scala/com/patson/NegotiationReadyNotifier.scala
@@ -1,0 +1,38 @@
+package com.patson
+
+import com.patson.data.{NegotiationSource, NotificationSource, SoloConfig}
+import com.patson.model.{NonPlayerAirline, Notification, NotificationCategory}
+import com.patson.model.negotiation.LinkNegotiationDiscount
+
+object NegotiationReadyNotifier {
+  def targetId(discount : LinkNegotiationDiscount) : String =
+    s"${discount.fromAirport.id}-${discount.toAirport.id}"
+
+  def message(discount : LinkNegotiationDiscount) : String =
+    s"Negotiation ready: ${discount.fromAirport.displayText} -> ${discount.toAirport.displayText} can be attempted again."
+
+  def notificationsToEmit(discounts : List[LinkNegotiationDiscount],
+                          alreadyExists : (Int, String) => Boolean) : List[Notification] = {
+    discounts
+      .filter(_.airline.airlineType != NonPlayerAirline)
+      .groupBy(discount => (discount.airline.id, targetId(discount)))
+      .values
+      .flatMap(_.sortBy(-_.expiry).headOption)
+      .filterNot(discount => alreadyExists(discount.airline.id, targetId(discount)))
+      .map { discount =>
+        Notification(discount.airline.id, NotificationCategory.NEGOTIATION_READY, message(discount), discount.expiry, targetId = Some(targetId(discount)))
+      }
+      .toList
+  }
+
+  def emit(cycle : Int) : Int = {
+    if (!SoloConfig.negotiationReadyEnabled) return 0
+    val notifications = notificationsToEmit(
+      NegotiationSource.loadExpiredLinkDiscounts(cycle),
+      (airlineId, id) => NotificationSource.existsByTargetId(airlineId, id, NotificationCategory.NEGOTIATION_READY)
+    )
+    NotificationSource.insertNotificationsBulk(notifications)
+    if (notifications.nonEmpty) println(s"[negotiation-ready] emitted ${notifications.size} notification(s)")
+    notifications.size
+  }
+}

--- a/airline-data/src/main/scala/com/patson/data/NegotiationSource.scala
+++ b/airline-data/src/main/scala/com/patson/data/NegotiationSource.scala
@@ -41,6 +41,13 @@ object NegotiationSource {
     loadLinkDiscountsByCriteria(List(("airline", airlineId), ("from_airport", fromAirportId), ("to_airport", toAirportId)))
   }
 
+  def loadExpiredLinkDiscounts(cutoffCycle : Int) : List[LinkNegotiationDiscount] = {
+    loadLinkDiscountsByQueryString(
+      "SELECT * FROM " + LINK_NEGOTIATION_DISCOUNT_TABLE + " WHERE expiration_cycle <= ?",
+      List(cutoffCycle)
+    )
+  }
+
   def loadLinkDiscountsByCriteria(criteria : List[(String, Any)], loadArea : Boolean = false) = {
     var queryString = "SELECT * FROM " + LINK_NEGOTIATION_DISCOUNT_TABLE
 

--- a/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
+++ b/airline-data/src/main/scala/com/patson/data/SoloConfig.scala
@@ -39,6 +39,11 @@ object SoloConfig {
   val notifyProfitMilestone : Long = longAt("solo.notify.profitMilestone", 10_000_000L)
   val notifyIntervalCycles : Int = intAt("solo.notify.intervalCycles", 4)
 
+  // Negotiation reminder: when enabled, failed-route negotiation discounts emit
+  // a one-time bell notification when their cooldown expires and the route can
+  // be attempted again. Off by default so default/multiplayer deploys are unchanged.
+  val negotiationReadyEnabled : Boolean = boolAt("solo.negotiationReady.enabled", false)
+
   // Diagnostic: split DemandGenerator timing into base-demand vs chunk-generation
   // to decide whether memoizing the base layer is worthwhile (off by default).
   val demandProfile : Boolean = boolAt("solo.demand.profile", false)

--- a/airline-data/src/main/scala/com/patson/model/Notification.scala
+++ b/airline-data/src/main/scala/com/patson/model/Notification.scala
@@ -23,6 +23,11 @@ object NotificationCategory extends Enumeration {
    *   Deleted:     on successful negotiation for the same route pair; expired ones
    *                purged by NotificationSource.purgeExpiredNegotiationLoss on getNotifications.
    *
+   * NEGOTIATION_READY — Single-player: emitted once when a NEGOTIATION_LOSS
+   *   discount reaches its expiry cycle and the route can be attempted again
+   *   (gated by solo.negotiationReady.enabled). targetId uses the same
+   *   "{fromAirportId}-{toAirportId}" navigation contract.
+   *
    * LEVEL_UP — Airline reached a new level.
    *   targetId: none
    *
@@ -63,5 +68,5 @@ object NotificationCategory extends Enumeration {
    *   bell — excluded from the bell unread count so it never nags. targetId optional, e.g.
    *   "rival_{airlineId}" for navigation. Subject to the normal retention purge.
    */
-  val NEGOTIATION_LOSS, LEVEL_UP, LOYALIST, GAME_OVER, OLYMPICS_PRIZE, TUTORIAL, LINK_CANCELLATION, CASH_FLOW_WARNING, PROFIT_MILESTONE, MILESTONE_ACHIEVED, WORLD_NEWS, CONSULTANT_ADVICE, MARKET_OVERVIEW = Value
+  val NEGOTIATION_LOSS, NEGOTIATION_READY, LEVEL_UP, LOYALIST, GAME_OVER, OLYMPICS_PRIZE, TUTORIAL, LINK_CANCELLATION, CASH_FLOW_WARNING, PROFIT_MILESTONE, MILESTONE_ACHIEVED, WORLD_NEWS, CONSULTANT_ADVICE, MARKET_OVERVIEW = Value
 }

--- a/airline-data/src/test/scala/com/patson/NegotiationReadyNotifierSpec.scala
+++ b/airline-data/src/test/scala/com/patson/NegotiationReadyNotifierSpec.scala
@@ -1,0 +1,44 @@
+package com.patson
+
+import com.patson.model._
+import com.patson.model.negotiation.LinkNegotiationDiscount
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class NegotiationReadyNotifierSpec extends AnyWordSpecLike with Matchers {
+  private val from = Airport.fromId(1).copy(iata = "RDU", name = "Raleigh-Durham")
+  private val to = Airport.fromId(2).copy(iata = "LHR", name = "Heathrow")
+  private val player = Airline.fromId(10).copy(name = "Player Air", airlineType = LegacyAirline)
+  private val npc = Airline.fromId(11).copy(name = "NPC Air", airlineType = NonPlayerAirline)
+
+  "NegotiationReadyNotifier" should {
+    "emit one notification per player route when no ready notification exists" in {
+      val discount = LinkNegotiationDiscount(player, from, to, BigDecimal("0.25"), expiry = 432)
+
+      val notifications = NegotiationReadyNotifier.notificationsToEmit(List(discount), (_, _) => false)
+
+      notifications should have size 1
+      notifications.head.category shouldBe NotificationCategory.NEGOTIATION_READY
+      notifications.head.airlineId shouldBe player.id
+      notifications.head.targetId shouldBe Some("1-2")
+      notifications.head.cycle shouldBe 432
+    }
+
+    "dedupe route reminders and skip NPC airlines" in {
+      val older = LinkNegotiationDiscount(player, from, to, BigDecimal("0.10"), expiry = 400)
+      val newer = LinkNegotiationDiscount(player, from, to, BigDecimal("0.20"), expiry = 432)
+      val npcDiscount = LinkNegotiationDiscount(npc, from, to, BigDecimal("0.20"), expiry = 432)
+
+      val notifications = NegotiationReadyNotifier.notificationsToEmit(List(older, newer, npcDiscount), (_, _) => false)
+
+      notifications should have size 1
+      notifications.head.cycle shouldBe 432
+    }
+
+    "skip reminders that already exist" in {
+      val discount = LinkNegotiationDiscount(player, from, to, BigDecimal("0.25"), expiry = 432)
+
+      NegotiationReadyNotifier.notificationsToEmit(List(discount), (_, _) => true) shouldBe empty
+    }
+  }
+}

--- a/airline-data/src/test/scala/com/patson/data/SoloConfigSpec.scala
+++ b/airline-data/src/test/scala/com/patson/data/SoloConfigSpec.scala
@@ -16,5 +16,6 @@ class SoloConfigSpec extends AnyFlatSpec with Matchers {
     SoloConfig.loanDefaultAnnualRate shouldBe 0.11
     SoloConfig.bankruptcyCashThreshold shouldBe -10000000
     SoloConfig.bankruptcyAssetsThreshold shouldBe -100000000
+    SoloConfig.negotiationReadyEnabled shouldBe false
   }
 }

--- a/airline-web/app/controllers/LinkApplication.scala
+++ b/airline-web/app/controllers/LinkApplication.scala
@@ -470,6 +470,11 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
           s"${resultLink.from.id}-${resultLink.to.id}",
           NotificationCategory.NEGOTIATION_LOSS
         )
+        NotificationSource.deleteNotificationsByTargetId(
+          airline.id,
+          s"${resultLink.from.id}-${resultLink.to.id}",
+          NotificationCategory.NEGOTIATION_READY
+        )
       }
 
       NegotiationUtil.getNextNegotiationDiscount(resultLink, negotiationResult).foreach { discount =>

--- a/airline-web/public/javascripts/notification.js
+++ b/airline-web/public/javascripts/notification.js
@@ -149,6 +149,7 @@ function getCategoryIcon(category) {
         case 'GAME_OVER': return '!'
         case 'OLYMPICS_PRIZE': return '🏅'
         case 'TUTORIAL': return '→'
+        case 'NEGOTIATION_READY': return '✓'
         case 'NEGOTIATION_LOSS':
         case 'CASH_FLOW_WARNING':
         case 'LINK_CANCELLATION': return '⚠'

--- a/docker-compose.small.yaml
+++ b/docker-compose.small.yaml
@@ -30,7 +30,7 @@ services:
     environment:
       DB_HOST: airline-db
       WEB_EXTRA_OPTS: "-Dmysqldb.host=airline-db:3306 ${WEB_SOLO_OPTS:--Dsolo.consultant.enabled=true -Dsolo.progression.enabled=true -Dsolo.news.enabled=true -Dsolo.lounge.allowWithoutAlliance=true -Dsolo.alliance.minMembers=2}"
-      SIM_EXTRA_OPTS: "-Dmysqldb.host=airline-db:3306 -Dsimulation.pauseWhenIdle=true ${SIM_SOLO_OPTS:--Dsolo.ap.generationRate=0.3 -Dsolo.loan.defaultAnnualRate=0.06 -Dsolo.bankruptcy.cashThreshold=-25000000 -Dsolo.bankruptcy.assetsThreshold=-150000000 -Dsolo.notify.enabled=true -Dsolo.demand.profile=true -Dsolo.ai.enabled=true -Dsolo.consultant.enabled=true -Dsolo.progression.enabled=true -Dsolo.news.enabled=true -Dsolo.lounge.allowWithoutAlliance=true -Dsolo.alliance.minMembers=2}"
+      SIM_EXTRA_OPTS: "-Dmysqldb.host=airline-db:3306 -Dsimulation.pauseWhenIdle=true ${SIM_SOLO_OPTS:--Dsolo.ap.generationRate=0.3 -Dsolo.loan.defaultAnnualRate=0.06 -Dsolo.bankruptcy.cashThreshold=-25000000 -Dsolo.bankruptcy.assetsThreshold=-150000000 -Dsolo.notify.enabled=true -Dsolo.negotiationReady.enabled=true -Dsolo.demand.profile=true -Dsolo.ai.enabled=true -Dsolo.consultant.enabled=true -Dsolo.progression.enabled=true -Dsolo.news.enabled=true -Dsolo.lounge.allowWithoutAlliance=true -Dsolo.alliance.minMembers=2}"
     entrypoint: ["sh", "/home/airline/start-small.sh"]
     # Required for docker inside an unprivileged LXC, where securityfs is
     # unreadable and the docker-default AppArmor profile can never load.


### PR DESCRIPTION
## Summary
- emit a bell notification when a failed-route negotiation cooldown reaches its expiry cycle
- clear stale ready notifications when the same route is successfully negotiated again
- enable the feature on the OptiPlex solo deploy while leaving defaults off

## Validation
- Not run locally: Java/SBT are not available on this Windows PATH, and local Docker is not connected. Opening this draft PR to run the repository CI compile gate.